### PR TITLE
Add `toArray` method generation

### DIFF
--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -134,6 +134,17 @@
               label="JSON response is an array"
             />
           </FormGroup>
+
+          <Label class="mt-2">
+            To Array
+          </Label>
+
+          <FormGroup>
+            <Checkbox
+              v-model="model.addToArrayMethod"
+              label="Add toArray method"
+            />
+          </FormGroup>
         </div>
       </div>
     </TabContent>

--- a/src/dto/Settings.ts
+++ b/src/dto/Settings.ts
@@ -32,6 +32,8 @@ export default interface Settings {
     addFromJsonMethod: boolean;
     jsonIsArray: boolean;
 
+    addToArrayMethod: boolean;
+
     docblock: PhpDocblock;
 
     namespace: string;
@@ -105,6 +107,8 @@ export const createDefaultSettings = (): Settings => {
 
         addFromJsonMethod: false,
         jsonIsArray: true,
+
+        addToArrayMethod: false,
 
         docblock: PhpDocblock.Necessary,
 

--- a/src/presenters/PhpClassPresenter.ts
+++ b/src/presenters/PhpClassPresenter.ts
@@ -9,6 +9,7 @@ import PhpClassFromJsonMethodPresenter from '@/presenters/PhpClassFromJsonMethod
 import PhpPropertyPresenter from '@/presenters/PhpPropertyPresenter';
 import PhpPropertyTypePresenter from '@/presenters/PhpPropertyTypePresenter';
 import CodeWriter from '@/writers/CodeWriter';
+import PhpClassToArrayMethodPresenter from '@/presenters/PhpClassToArrayMethodPresenter';
 
 export default class PhpClassPresenter {
     private readonly phpClass: PhpClass;
@@ -91,6 +92,12 @@ export default class PhpClassPresenter {
         if (this.settings.addFromJsonMethod) {
             codeWriter.insertNewLine();
             (new PhpClassFromJsonMethodPresenter(propertyTypePresenters, this.settings)).write(codeWriter);
+        }
+
+        // toArray method
+        if (this.settings.addToArrayMethod) {
+            codeWriter.insertNewLine();
+            (new PhpClassToArrayMethodPresenter(propertyTypePresenters)).write(codeWriter);
         }
 
         // close current class

--- a/src/presenters/PhpClassPresenter.ts
+++ b/src/presenters/PhpClassPresenter.ts
@@ -97,7 +97,7 @@ export default class PhpClassPresenter {
         // toArray method
         if (this.settings.addToArrayMethod) {
             codeWriter.insertNewLine();
-            (new PhpClassToArrayMethodPresenter(propertyTypePresenters)).write(codeWriter);
+            (new PhpClassToArrayMethodPresenter(propertyTypePresenters, this.settings)).write(codeWriter);
         }
 
         // close current class

--- a/src/presenters/PhpClassToArrayMethodPresenter.ts
+++ b/src/presenters/PhpClassToArrayMethodPresenter.ts
@@ -3,21 +3,27 @@ import PhpPropertyTypePresenter from '@/presenters/PhpPropertyTypePresenter';
 import CodeWriter from '@/writers/CodeWriter';
 import {PhpVisibility} from '@/enums/PhpVisibility';
 import PhpClassType from '@/php-types/PhpClassType';
+import {PhpDocblock} from '@/enums/PhpDocblock';
+import Settings from '@/dto/Settings';
 
 export default class PhpClassToArrayMethodPresenter {
     private readonly propertyTypePresenter: PhpPropertyTypePresenter[];
+    private readonly settings: Settings;
 
-    public constructor(propertyTypePresenter: PhpPropertyTypePresenter[]) {
+    public constructor(propertyTypePresenter: PhpPropertyTypePresenter[], settings: Settings) {
         this.propertyTypePresenter = propertyTypePresenter;
+        this.settings = settings;
     }
 
     public write(codeWriter: CodeWriter): void {
-        // Add method docblock
-        const docblockLines = [
-            '@return array'
-        ];
-        
-        codeWriter.writeMultilineDocblock(docblockLines);
+        // Add method docblock only if propertyDocblock is set to 'all'
+        if (this.settings.docblock === PhpDocblock.All) {
+            const docblockLines = [
+                '@return array'
+            ];
+            
+            codeWriter.writeMultilineDocblock(docblockLines);
+        }
 
         // Open method definition
         codeWriter.openMethod(

--- a/src/presenters/PhpClassToArrayMethodPresenter.ts
+++ b/src/presenters/PhpClassToArrayMethodPresenter.ts
@@ -1,0 +1,103 @@
+import ArrayType from '@/php-types/ArrayType';
+import PhpPropertyTypePresenter from '@/presenters/PhpPropertyTypePresenter';
+import CodeWriter from '@/writers/CodeWriter';
+import {PhpVisibility} from '@/enums/PhpVisibility';
+import PhpClassType from '@/php-types/PhpClassType';
+
+export default class PhpClassToArrayMethodPresenter {
+    private readonly propertyTypePresenter: PhpPropertyTypePresenter[];
+
+    public constructor(propertyTypePresenter: PhpPropertyTypePresenter[]) {
+        this.propertyTypePresenter = propertyTypePresenter;
+    }
+
+    public write(codeWriter: CodeWriter): void {
+        const returnType = 'array';
+
+        // Add method docblock
+        const docblockLines = [
+            '@return array'
+        ];
+        
+        codeWriter.writeMultilineDocblock(docblockLines);
+
+        // Open method definition
+        codeWriter.openMethod(
+            PhpVisibility.Public,
+            'toArray',
+            returnType,
+            [],
+            {isStatic: false}
+        );
+
+        // Start generating array
+        codeWriter.writeLine('return [');
+        codeWriter.indent();
+
+        // Iterate through all properties
+        for (let i = 0; i < this.propertyTypePresenter.length; i++) {
+            const presenter = this.propertyTypePresenter[i];
+            const property = presenter.getProperty();
+            const propertyName = property.getName();
+            
+            const lines = this.getPropertyToArrayCode(presenter);
+            
+            // Add array key-value pair
+            if (lines.length === 1) {
+                codeWriter.writeLine(`'${propertyName}' => ${lines[0]}${i < this.propertyTypePresenter.length - 1 ? ',' : ''}`);
+            } else {
+                codeWriter.writeLine(`'${propertyName}' => ${lines[0]}`);
+                codeWriter.indent();
+                
+                for (let j = 1; j < lines.length - 1; j++) {
+                    codeWriter.writeLine(lines[j]);
+                }
+                
+                codeWriter.outdent();
+                codeWriter.writeLine(`${lines[lines.length - 1]}${i < this.propertyTypePresenter.length - 1 ? ',' : ''}`);
+            }
+        }
+
+        codeWriter.outdent();
+        codeWriter.writeLine('];');
+        codeWriter.closeMethod();
+    }
+
+    private getPropertyToArrayCode(typePresenter: PhpPropertyTypePresenter): string[] {
+        const property = typePresenter.getProperty();
+        const propertyAccess = `$this->${property.getName()}`;
+
+        // Handle array type properties
+        const classArrayType = property.getTypes()
+            .find(type => type instanceof ArrayType && type.isPhpClassArray()) as ArrayType | undefined;
+
+        if (classArrayType) {
+            if (property.isNullable()) {
+                return [
+                    `${propertyAccess} !== null ? array_map(function($item) {`,
+                    '    return $item->toArray();',
+                    `}, ${propertyAccess}) : null`
+                ];
+            }
+            
+            return [
+                'array_map(function($item) {',
+                '    return $item->toArray();',
+                `}, ${propertyAccess})`
+            ];
+        }
+
+        // Handle object type properties
+        const phpClass = property.getTypes().find(t => t instanceof PhpClassType) as PhpClassType | undefined;
+        
+        if (phpClass) {
+            if (property.isNullable()) {
+                return [`${propertyAccess} !== null ? ${propertyAccess}->toArray() : null`];
+            }
+            return [`${propertyAccess}->toArray()`];
+        }
+
+        // Handle primitive type properties
+        return [propertyAccess];
+    }
+} 

--- a/src/presenters/PhpClassToArrayMethodPresenter.ts
+++ b/src/presenters/PhpClassToArrayMethodPresenter.ts
@@ -12,8 +12,6 @@ export default class PhpClassToArrayMethodPresenter {
     }
 
     public write(codeWriter: CodeWriter): void {
-        const returnType = 'array';
-
         // Add method docblock
         const docblockLines = [
             '@return array'
@@ -25,7 +23,7 @@ export default class PhpClassToArrayMethodPresenter {
         codeWriter.openMethod(
             PhpVisibility.Public,
             'toArray',
-            returnType,
+            'array',
             [],
             {isStatic: false}
         );

--- a/src/presenters/PhpClassToArrayMethodPresenter.ts
+++ b/src/presenters/PhpClassToArrayMethodPresenter.ts
@@ -69,7 +69,7 @@ export default class PhpClassToArrayMethodPresenter {
 
     private getPropertyToArrayCode(typePresenter: PhpPropertyTypePresenter): string[] {
         const property = typePresenter.getProperty();
-        const propertyAccess = `$this->${property.getName()}`;
+        const propertyAccess = `$this->${typePresenter.getPhpVarName()}`
 
         // Handle array type properties
         const classArrayType = property.getTypes()
@@ -78,14 +78,14 @@ export default class PhpClassToArrayMethodPresenter {
         if (classArrayType) {
             if (property.isNullable()) {
                 return [
-                    `${propertyAccess} !== null ? array_map(function($item) {`,
+                    `${propertyAccess} !== null ? array_map(static function($item) {`,
                     '    return $item->toArray();',
                     `}, ${propertyAccess}) : null`
                 ];
             }
             
             return [
-                'array_map(function($item) {',
+                'array_map(static function($item) {',
                 '    return $item->toArray();',
                 `}, ${propertyAccess})`
             ];

--- a/tests/converter/fixtures/results/all_types_json_php_7_3_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_7_3_with_from_json_and_to_array_methods.txt
@@ -31,9 +31,6 @@ class RootObject
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -64,9 +61,6 @@ class NestedClass
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/all_types_json_php_7_3_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_7_3_with_from_json_and_to_array_methods.txt
@@ -34,15 +34,15 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'string_array' => $this->string_array,
-			'mixed_array' => $this->mixed_array,
-			'null_array' => $this->null_array,
-			'unknown_array' => $this->unknown_array,
+			'string_array' => $this->stringArray,
+			'mixed_array' => $this->mixedArray,
+			'null_array' => $this->nullArray,
+			'unknown_array' => $this->unknownArray,
 			'boolean' => $this->boolean,
 			'float' => $this->float,
 			'int' => $this->int,
 			'null' => $this->null,
-			'nested_class' => $this->nested_class->toArray(),
+			'nested_class' => $this->nestedClass->toArray(),
 			'string' => $this->string
 		];
 	}

--- a/tests/converter/fixtures/results/all_types_json_php_7_3_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_7_3_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,76 @@
+<?php
+
+class RootObject
+{
+	/** @var string[] */
+	public $stringArray;
+	/** @var (string|int|null)[] */
+	public $mixedArray;
+	public $nullArray;
+	public $unknownArray;
+	public $boolean;
+	public $float;
+	public $int;
+	public $null;
+	public $nestedClass;
+	public $string;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->stringArray = $data->string_array;
+		$instance->mixedArray = $data->mixed_array;
+		$instance->nullArray = $data->null_array;
+		$instance->unknownArray = $data->unknown_array;
+		$instance->boolean = $data->boolean;
+		$instance->float = $data->float;
+		$instance->int = $data->int;
+		$instance->null = $data->null ?? null;
+		$instance->nestedClass = NestedClass::fromJson($data->nested_class);
+		$instance->string = $data->string;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'string_array' => $this->string_array,
+			'mixed_array' => $this->mixed_array,
+			'null_array' => $this->null_array,
+			'unknown_array' => $this->unknown_array,
+			'boolean' => $this->boolean,
+			'float' => $this->float,
+			'int' => $this->int,
+			'null' => $this->null,
+			'nested_class' => $this->nested_class->toArray(),
+			'string' => $this->string
+		];
+	}
+}
+
+<?php
+
+class NestedClass
+{
+	public $var;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->var = $data->var;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'var' => $this->var
+		];
+	}
+}

--- a/tests/converter/fixtures/results/all_types_json_php_7_3_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_7_3_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
@@ -1,0 +1,322 @@
+<?php
+
+class RootObject
+{
+	/**
+	 * @var string[]
+	 */
+	public $stringArray;
+
+	/**
+	 * @var (string|int|null)[]
+	 */
+	public $mixedArray;
+
+	/**
+	 * @var array
+	 */
+	public $nullArray;
+
+	/**
+	 * @var array
+	 */
+	public $unknownArray;
+
+	/**
+	 * @var bool
+	 */
+	public $boolean;
+
+	/**
+	 * @var float
+	 */
+	public $float;
+
+	/**
+	 * @var int
+	 */
+	public $int;
+
+	/**
+	 * @var |null
+	 */
+	public $null;
+
+	/**
+	 * @var NestedClass
+	 */
+	public $nestedClass;
+
+	/**
+	 * @var string
+	 */
+	public $string;
+
+	/**
+	 * @return string[]
+	 */
+	public function getStringArray(): array
+	{
+		return $this->stringArray;
+	}
+
+	/**
+	 * @return (string|int|null)[]
+	 */
+	public function getMixedArray(): array
+	{
+		return $this->mixedArray;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getNullArray(): array
+	{
+		return $this->nullArray;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getUnknownArray(): array
+	{
+		return $this->unknownArray;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function getBoolean(): bool
+	{
+		return $this->boolean;
+	}
+
+	/**
+	 * @return float
+	 */
+	public function getFloat(): float
+	{
+		return $this->float;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getInt(): int
+	{
+		return $this->int;
+	}
+
+	/**
+	 * @return |null
+	 */
+	public function getNull()
+	{
+		return $this->null;
+	}
+
+	/**
+	 * @return NestedClass
+	 */
+	public function getNestedClass(): NestedClass
+	{
+		return $this->nestedClass;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getString(): string
+	{
+		return $this->string;
+	}
+
+	/**
+	 * @param string[] $stringArray
+	 * @return self
+	 */
+	public function setStringArray(array $stringArray): self
+	{
+		$this->stringArray = $stringArray;
+		return $this;
+	}
+
+	/**
+	 * @param (string|int|null)[] $mixedArray
+	 * @return self
+	 */
+	public function setMixedArray(array $mixedArray): self
+	{
+		$this->mixedArray = $mixedArray;
+		return $this;
+	}
+
+	/**
+	 * @param array $nullArray
+	 * @return self
+	 */
+	public function setNullArray(array $nullArray): self
+	{
+		$this->nullArray = $nullArray;
+		return $this;
+	}
+
+	/**
+	 * @param array $unknownArray
+	 * @return self
+	 */
+	public function setUnknownArray(array $unknownArray): self
+	{
+		$this->unknownArray = $unknownArray;
+		return $this;
+	}
+
+	/**
+	 * @param bool $boolean
+	 * @return self
+	 */
+	public function setBoolean(bool $boolean): self
+	{
+		$this->boolean = $boolean;
+		return $this;
+	}
+
+	/**
+	 * @param float $float
+	 * @return self
+	 */
+	public function setFloat(float $float): self
+	{
+		$this->float = $float;
+		return $this;
+	}
+
+	/**
+	 * @param int $int
+	 * @return self
+	 */
+	public function setInt(int $int): self
+	{
+		$this->int = $int;
+		return $this;
+	}
+
+	/**
+	 * @param |null $null
+	 * @return self
+	 */
+	public function setNull($null): self
+	{
+		$this->null = $null;
+		return $this;
+	}
+
+	/**
+	 * @param NestedClass $nestedClass
+	 * @return self
+	 */
+	public function setNestedClass(NestedClass $nestedClass): self
+	{
+		$this->nestedClass = $nestedClass;
+		return $this;
+	}
+
+	/**
+	 * @param string $string
+	 * @return self
+	 */
+	public function setString(string $string): self
+	{
+		$this->string = $string;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setStringArray($data['string_array']);
+		$instance->setMixedArray($data['mixed_array']);
+		$instance->setNullArray($data['null_array']);
+		$instance->setUnknownArray($data['unknown_array']);
+		$instance->setBoolean($data['boolean']);
+		$instance->setFloat($data['float']);
+		$instance->setInt($data['int']);
+		$instance->setNull($data['null'] ?? null);
+		$instance->setNestedClass(NestedClass::fromJson($data['nested_class']));
+		$instance->setString($data['string']);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'string_array' => $this->string_array,
+			'mixed_array' => $this->mixed_array,
+			'null_array' => $this->null_array,
+			'unknown_array' => $this->unknown_array,
+			'boolean' => $this->boolean,
+			'float' => $this->float,
+			'int' => $this->int,
+			'null' => $this->null,
+			'nested_class' => $this->nested_class->toArray(),
+			'string' => $this->string
+		];
+	}
+}
+
+<?php
+
+class NestedClass
+{
+	/**
+	 * @var int
+	 */
+	public $var;
+
+	/**
+	 * @return int
+	 */
+	public function getVar(): int
+	{
+		return $this->var;
+	}
+
+	/**
+	 * @param int $var
+	 * @return self
+	 */
+	public function setVar(int $var): self
+	{
+		$this->var = $var;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setVar($data['var']);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'var' => $this->var
+		];
+	}
+}

--- a/tests/converter/fixtures/results/all_types_json_php_7_3_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_7_3_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
@@ -258,15 +258,15 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'string_array' => $this->string_array,
-			'mixed_array' => $this->mixed_array,
-			'null_array' => $this->null_array,
-			'unknown_array' => $this->unknown_array,
+			'string_array' => $this->stringArray,
+			'mixed_array' => $this->mixedArray,
+			'null_array' => $this->nullArray,
+			'unknown_array' => $this->unknownArray,
 			'boolean' => $this->boolean,
 			'float' => $this->float,
 			'int' => $this->int,
 			'null' => $this->null,
-			'nested_class' => $this->nested_class->toArray(),
+			'nested_class' => $this->nestedClass->toArray(),
 			'string' => $this->string
 		];
 	}

--- a/tests/converter/fixtures/results/all_types_json_php_7_3_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_7_3_with_to_array_method.txt
@@ -18,15 +18,15 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'string_array' => $this->string_array,
-			'mixed_array' => $this->mixed_array,
-			'null_array' => $this->null_array,
-			'unknown_array' => $this->unknown_array,
+			'string_array' => $this->stringArray,
+			'mixed_array' => $this->mixedArray,
+			'null_array' => $this->nullArray,
+			'unknown_array' => $this->unknownArray,
 			'boolean' => $this->boolean,
 			'float' => $this->float,
 			'int' => $this->int,
 			'null' => $this->null,
-			'nested_class' => $this->nested_class->toArray(),
+			'nested_class' => $this->nestedClass->toArray(),
 			'string' => $this->string
 		];
 	}

--- a/tests/converter/fixtures/results/all_types_json_php_7_3_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_7_3_with_to_array_method.txt
@@ -15,9 +15,6 @@ class RootObject
 	public $nestedClass;
 	public $string;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -41,9 +38,6 @@ class NestedClass
 {
 	public $var;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/all_types_json_php_7_3_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_7_3_with_to_array_method.txt
@@ -1,0 +1,53 @@
+<?php
+
+class RootObject
+{
+	/** @var string[] */
+	public $stringArray;
+	/** @var (string|int|null)[] */
+	public $mixedArray;
+	public $nullArray;
+	public $unknownArray;
+	public $boolean;
+	public $float;
+	public $int;
+	public $null;
+	public $nestedClass;
+	public $string;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'string_array' => $this->string_array,
+			'mixed_array' => $this->mixed_array,
+			'null_array' => $this->null_array,
+			'unknown_array' => $this->unknown_array,
+			'boolean' => $this->boolean,
+			'float' => $this->float,
+			'int' => $this->int,
+			'null' => $this->null,
+			'nested_class' => $this->nested_class->toArray(),
+			'string' => $this->string
+		];
+	}
+}
+
+<?php
+
+class NestedClass
+{
+	public $var;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'var' => $this->var
+		];
+	}
+}

--- a/tests/converter/fixtures/results/all_types_json_php_7_4_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_7_4_with_from_json_and_to_array_methods.txt
@@ -31,9 +31,6 @@ class RootObject
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -64,9 +61,6 @@ class NestedClass
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/all_types_json_php_7_4_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_7_4_with_from_json_and_to_array_methods.txt
@@ -34,15 +34,15 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'string_array' => $this->string_array,
-			'mixed_array' => $this->mixed_array,
-			'null_array' => $this->null_array,
-			'unknown_array' => $this->unknown_array,
+			'string_array' => $this->stringArray,
+			'mixed_array' => $this->mixedArray,
+			'null_array' => $this->nullArray,
+			'unknown_array' => $this->unknownArray,
 			'boolean' => $this->boolean,
 			'float' => $this->float,
 			'int' => $this->int,
 			'null' => $this->null,
-			'nested_class' => $this->nested_class->toArray(),
+			'nested_class' => $this->nestedClass->toArray(),
 			'string' => $this->string
 		];
 	}

--- a/tests/converter/fixtures/results/all_types_json_php_7_4_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_7_4_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,76 @@
+<?php
+
+class RootObject
+{
+	/** @var string[] */
+	public array $stringArray;
+	/** @var (string|int|null)[] */
+	public array $mixedArray;
+	public array $nullArray;
+	public array $unknownArray;
+	public bool $boolean;
+	public float $float;
+	public int $int;
+	public $null;
+	public NestedClass $nestedClass;
+	public string $string;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->stringArray = $data->string_array;
+		$instance->mixedArray = $data->mixed_array;
+		$instance->nullArray = $data->null_array;
+		$instance->unknownArray = $data->unknown_array;
+		$instance->boolean = $data->boolean;
+		$instance->float = $data->float;
+		$instance->int = $data->int;
+		$instance->null = $data->null ?? null;
+		$instance->nestedClass = NestedClass::fromJson($data->nested_class);
+		$instance->string = $data->string;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'string_array' => $this->string_array,
+			'mixed_array' => $this->mixed_array,
+			'null_array' => $this->null_array,
+			'unknown_array' => $this->unknown_array,
+			'boolean' => $this->boolean,
+			'float' => $this->float,
+			'int' => $this->int,
+			'null' => $this->null,
+			'nested_class' => $this->nested_class->toArray(),
+			'string' => $this->string
+		];
+	}
+}
+
+<?php
+
+class NestedClass
+{
+	public int $var;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->var = $data->var;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'var' => $this->var
+		];
+	}
+}

--- a/tests/converter/fixtures/results/all_types_json_php_7_4_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_7_4_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
@@ -258,15 +258,15 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'string_array' => $this->string_array,
-			'mixed_array' => $this->mixed_array,
-			'null_array' => $this->null_array,
-			'unknown_array' => $this->unknown_array,
+			'string_array' => $this->stringArray,
+			'mixed_array' => $this->mixedArray,
+			'null_array' => $this->nullArray,
+			'unknown_array' => $this->unknownArray,
 			'boolean' => $this->boolean,
 			'float' => $this->float,
 			'int' => $this->int,
 			'null' => $this->null,
-			'nested_class' => $this->nested_class->toArray(),
+			'nested_class' => $this->nestedClass->toArray(),
 			'string' => $this->string
 		];
 	}

--- a/tests/converter/fixtures/results/all_types_json_php_7_4_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_7_4_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
@@ -1,0 +1,322 @@
+<?php
+
+class RootObject
+{
+	/**
+	 * @var string[]
+	 */
+	public array $stringArray;
+
+	/**
+	 * @var (string|int|null)[]
+	 */
+	public array $mixedArray;
+
+	/**
+	 * @var array
+	 */
+	public array $nullArray;
+
+	/**
+	 * @var array
+	 */
+	public array $unknownArray;
+
+	/**
+	 * @var bool
+	 */
+	public bool $boolean;
+
+	/**
+	 * @var float
+	 */
+	public float $float;
+
+	/**
+	 * @var int
+	 */
+	public int $int;
+
+	/**
+	 * @var |null
+	 */
+	public $null;
+
+	/**
+	 * @var NestedClass
+	 */
+	public NestedClass $nestedClass;
+
+	/**
+	 * @var string
+	 */
+	public string $string;
+
+	/**
+	 * @return string[]
+	 */
+	public function getStringArray(): array
+	{
+		return $this->stringArray;
+	}
+
+	/**
+	 * @return (string|int|null)[]
+	 */
+	public function getMixedArray(): array
+	{
+		return $this->mixedArray;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getNullArray(): array
+	{
+		return $this->nullArray;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getUnknownArray(): array
+	{
+		return $this->unknownArray;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function getBoolean(): bool
+	{
+		return $this->boolean;
+	}
+
+	/**
+	 * @return float
+	 */
+	public function getFloat(): float
+	{
+		return $this->float;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getInt(): int
+	{
+		return $this->int;
+	}
+
+	/**
+	 * @return |null
+	 */
+	public function getNull()
+	{
+		return $this->null;
+	}
+
+	/**
+	 * @return NestedClass
+	 */
+	public function getNestedClass(): NestedClass
+	{
+		return $this->nestedClass;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getString(): string
+	{
+		return $this->string;
+	}
+
+	/**
+	 * @param string[] $stringArray
+	 * @return self
+	 */
+	public function setStringArray(array $stringArray): self
+	{
+		$this->stringArray = $stringArray;
+		return $this;
+	}
+
+	/**
+	 * @param (string|int|null)[] $mixedArray
+	 * @return self
+	 */
+	public function setMixedArray(array $mixedArray): self
+	{
+		$this->mixedArray = $mixedArray;
+		return $this;
+	}
+
+	/**
+	 * @param array $nullArray
+	 * @return self
+	 */
+	public function setNullArray(array $nullArray): self
+	{
+		$this->nullArray = $nullArray;
+		return $this;
+	}
+
+	/**
+	 * @param array $unknownArray
+	 * @return self
+	 */
+	public function setUnknownArray(array $unknownArray): self
+	{
+		$this->unknownArray = $unknownArray;
+		return $this;
+	}
+
+	/**
+	 * @param bool $boolean
+	 * @return self
+	 */
+	public function setBoolean(bool $boolean): self
+	{
+		$this->boolean = $boolean;
+		return $this;
+	}
+
+	/**
+	 * @param float $float
+	 * @return self
+	 */
+	public function setFloat(float $float): self
+	{
+		$this->float = $float;
+		return $this;
+	}
+
+	/**
+	 * @param int $int
+	 * @return self
+	 */
+	public function setInt(int $int): self
+	{
+		$this->int = $int;
+		return $this;
+	}
+
+	/**
+	 * @param |null $null
+	 * @return self
+	 */
+	public function setNull($null): self
+	{
+		$this->null = $null;
+		return $this;
+	}
+
+	/**
+	 * @param NestedClass $nestedClass
+	 * @return self
+	 */
+	public function setNestedClass(NestedClass $nestedClass): self
+	{
+		$this->nestedClass = $nestedClass;
+		return $this;
+	}
+
+	/**
+	 * @param string $string
+	 * @return self
+	 */
+	public function setString(string $string): self
+	{
+		$this->string = $string;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setStringArray($data['string_array']);
+		$instance->setMixedArray($data['mixed_array']);
+		$instance->setNullArray($data['null_array']);
+		$instance->setUnknownArray($data['unknown_array']);
+		$instance->setBoolean($data['boolean']);
+		$instance->setFloat($data['float']);
+		$instance->setInt($data['int']);
+		$instance->setNull($data['null'] ?? null);
+		$instance->setNestedClass(NestedClass::fromJson($data['nested_class']));
+		$instance->setString($data['string']);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'string_array' => $this->string_array,
+			'mixed_array' => $this->mixed_array,
+			'null_array' => $this->null_array,
+			'unknown_array' => $this->unknown_array,
+			'boolean' => $this->boolean,
+			'float' => $this->float,
+			'int' => $this->int,
+			'null' => $this->null,
+			'nested_class' => $this->nested_class->toArray(),
+			'string' => $this->string
+		];
+	}
+}
+
+<?php
+
+class NestedClass
+{
+	/**
+	 * @var int
+	 */
+	public int $var;
+
+	/**
+	 * @return int
+	 */
+	public function getVar(): int
+	{
+		return $this->var;
+	}
+
+	/**
+	 * @param int $var
+	 * @return self
+	 */
+	public function setVar(int $var): self
+	{
+		$this->var = $var;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setVar($data['var']);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'var' => $this->var
+		];
+	}
+}

--- a/tests/converter/fixtures/results/all_types_json_php_7_4_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_7_4_with_to_array_method.txt
@@ -18,15 +18,15 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'string_array' => $this->string_array,
-			'mixed_array' => $this->mixed_array,
-			'null_array' => $this->null_array,
-			'unknown_array' => $this->unknown_array,
+			'string_array' => $this->stringArray,
+			'mixed_array' => $this->mixedArray,
+			'null_array' => $this->nullArray,
+			'unknown_array' => $this->unknownArray,
 			'boolean' => $this->boolean,
 			'float' => $this->float,
 			'int' => $this->int,
 			'null' => $this->null,
-			'nested_class' => $this->nested_class->toArray(),
+			'nested_class' => $this->nestedClass->toArray(),
 			'string' => $this->string
 		];
 	}

--- a/tests/converter/fixtures/results/all_types_json_php_7_4_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_7_4_with_to_array_method.txt
@@ -1,0 +1,53 @@
+<?php
+
+class RootObject
+{
+	/** @var string[] */
+	public array $stringArray;
+	/** @var (string|int|null)[] */
+	public array $mixedArray;
+	public array $nullArray;
+	public array $unknownArray;
+	public bool $boolean;
+	public float $float;
+	public int $int;
+	public $null;
+	public NestedClass $nestedClass;
+	public string $string;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'string_array' => $this->string_array,
+			'mixed_array' => $this->mixed_array,
+			'null_array' => $this->null_array,
+			'unknown_array' => $this->unknown_array,
+			'boolean' => $this->boolean,
+			'float' => $this->float,
+			'int' => $this->int,
+			'null' => $this->null,
+			'nested_class' => $this->nested_class->toArray(),
+			'string' => $this->string
+		];
+	}
+}
+
+<?php
+
+class NestedClass
+{
+	public int $var;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'var' => $this->var
+		];
+	}
+}

--- a/tests/converter/fixtures/results/all_types_json_php_7_4_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_7_4_with_to_array_method.txt
@@ -15,9 +15,6 @@ class RootObject
 	public NestedClass $nestedClass;
 	public string $string;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -41,9 +38,6 @@ class NestedClass
 {
 	public int $var;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/all_types_json_php_8_0_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_0_with_from_json_and_to_array_methods.txt
@@ -31,9 +31,6 @@ class RootObject
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -64,9 +61,6 @@ class NestedClass
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/all_types_json_php_8_0_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_0_with_from_json_and_to_array_methods.txt
@@ -34,15 +34,15 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'string_array' => $this->string_array,
-			'mixed_array' => $this->mixed_array,
-			'null_array' => $this->null_array,
-			'unknown_array' => $this->unknown_array,
+			'string_array' => $this->stringArray,
+			'mixed_array' => $this->mixedArray,
+			'null_array' => $this->nullArray,
+			'unknown_array' => $this->unknownArray,
 			'boolean' => $this->boolean,
 			'float' => $this->float,
 			'int' => $this->int,
 			'null' => $this->null,
-			'nested_class' => $this->nested_class->toArray(),
+			'nested_class' => $this->nestedClass->toArray(),
 			'string' => $this->string
 		];
 	}

--- a/tests/converter/fixtures/results/all_types_json_php_8_0_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_0_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,76 @@
+<?php
+
+class RootObject
+{
+	/** @var string[] */
+	public array $stringArray;
+	/** @var (string|int|null)[] */
+	public array $mixedArray;
+	public array $nullArray;
+	public array $unknownArray;
+	public bool $boolean;
+	public float $float;
+	public int $int;
+	public null $null;
+	public NestedClass $nestedClass;
+	public string $string;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->stringArray = $data->string_array;
+		$instance->mixedArray = $data->mixed_array;
+		$instance->nullArray = $data->null_array;
+		$instance->unknownArray = $data->unknown_array;
+		$instance->boolean = $data->boolean;
+		$instance->float = $data->float;
+		$instance->int = $data->int;
+		$instance->null = $data->null ?? null;
+		$instance->nestedClass = NestedClass::fromJson($data->nested_class);
+		$instance->string = $data->string;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'string_array' => $this->string_array,
+			'mixed_array' => $this->mixed_array,
+			'null_array' => $this->null_array,
+			'unknown_array' => $this->unknown_array,
+			'boolean' => $this->boolean,
+			'float' => $this->float,
+			'int' => $this->int,
+			'null' => $this->null,
+			'nested_class' => $this->nested_class->toArray(),
+			'string' => $this->string
+		];
+	}
+}
+
+<?php
+
+class NestedClass
+{
+	public int $var;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->var = $data->var;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'var' => $this->var
+		];
+	}
+}

--- a/tests/converter/fixtures/results/all_types_json_php_8_0_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_0_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
@@ -1,0 +1,322 @@
+<?php
+
+class RootObject
+{
+	/**
+	 * @var string[]
+	 */
+	public array $stringArray;
+
+	/**
+	 * @var (string|int|null)[]
+	 */
+	public array $mixedArray;
+
+	/**
+	 * @var array
+	 */
+	public array $nullArray;
+
+	/**
+	 * @var array
+	 */
+	public array $unknownArray;
+
+	/**
+	 * @var bool
+	 */
+	public bool $boolean;
+
+	/**
+	 * @var float
+	 */
+	public float $float;
+
+	/**
+	 * @var int
+	 */
+	public int $int;
+
+	/**
+	 * @var |null
+	 */
+	public null $null;
+
+	/**
+	 * @var NestedClass
+	 */
+	public NestedClass $nestedClass;
+
+	/**
+	 * @var string
+	 */
+	public string $string;
+
+	/**
+	 * @return string[]
+	 */
+	public function getStringArray(): array
+	{
+		return $this->stringArray;
+	}
+
+	/**
+	 * @return (string|int|null)[]
+	 */
+	public function getMixedArray(): array
+	{
+		return $this->mixedArray;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getNullArray(): array
+	{
+		return $this->nullArray;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getUnknownArray(): array
+	{
+		return $this->unknownArray;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function getBoolean(): bool
+	{
+		return $this->boolean;
+	}
+
+	/**
+	 * @return float
+	 */
+	public function getFloat(): float
+	{
+		return $this->float;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getInt(): int
+	{
+		return $this->int;
+	}
+
+	/**
+	 * @return |null
+	 */
+	public function getNull(): null
+	{
+		return $this->null;
+	}
+
+	/**
+	 * @return NestedClass
+	 */
+	public function getNestedClass(): NestedClass
+	{
+		return $this->nestedClass;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getString(): string
+	{
+		return $this->string;
+	}
+
+	/**
+	 * @param string[] $stringArray
+	 * @return self
+	 */
+	public function setStringArray(array $stringArray): self
+	{
+		$this->stringArray = $stringArray;
+		return $this;
+	}
+
+	/**
+	 * @param (string|int|null)[] $mixedArray
+	 * @return self
+	 */
+	public function setMixedArray(array $mixedArray): self
+	{
+		$this->mixedArray = $mixedArray;
+		return $this;
+	}
+
+	/**
+	 * @param array $nullArray
+	 * @return self
+	 */
+	public function setNullArray(array $nullArray): self
+	{
+		$this->nullArray = $nullArray;
+		return $this;
+	}
+
+	/**
+	 * @param array $unknownArray
+	 * @return self
+	 */
+	public function setUnknownArray(array $unknownArray): self
+	{
+		$this->unknownArray = $unknownArray;
+		return $this;
+	}
+
+	/**
+	 * @param bool $boolean
+	 * @return self
+	 */
+	public function setBoolean(bool $boolean): self
+	{
+		$this->boolean = $boolean;
+		return $this;
+	}
+
+	/**
+	 * @param float $float
+	 * @return self
+	 */
+	public function setFloat(float $float): self
+	{
+		$this->float = $float;
+		return $this;
+	}
+
+	/**
+	 * @param int $int
+	 * @return self
+	 */
+	public function setInt(int $int): self
+	{
+		$this->int = $int;
+		return $this;
+	}
+
+	/**
+	 * @param |null $null
+	 * @return self
+	 */
+	public function setNull(null $null): self
+	{
+		$this->null = $null;
+		return $this;
+	}
+
+	/**
+	 * @param NestedClass $nestedClass
+	 * @return self
+	 */
+	public function setNestedClass(NestedClass $nestedClass): self
+	{
+		$this->nestedClass = $nestedClass;
+		return $this;
+	}
+
+	/**
+	 * @param string $string
+	 * @return self
+	 */
+	public function setString(string $string): self
+	{
+		$this->string = $string;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setStringArray($data['string_array']);
+		$instance->setMixedArray($data['mixed_array']);
+		$instance->setNullArray($data['null_array']);
+		$instance->setUnknownArray($data['unknown_array']);
+		$instance->setBoolean($data['boolean']);
+		$instance->setFloat($data['float']);
+		$instance->setInt($data['int']);
+		$instance->setNull($data['null'] ?? null);
+		$instance->setNestedClass(NestedClass::fromJson($data['nested_class']));
+		$instance->setString($data['string']);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'string_array' => $this->string_array,
+			'mixed_array' => $this->mixed_array,
+			'null_array' => $this->null_array,
+			'unknown_array' => $this->unknown_array,
+			'boolean' => $this->boolean,
+			'float' => $this->float,
+			'int' => $this->int,
+			'null' => $this->null,
+			'nested_class' => $this->nested_class->toArray(),
+			'string' => $this->string
+		];
+	}
+}
+
+<?php
+
+class NestedClass
+{
+	/**
+	 * @var int
+	 */
+	public int $var;
+
+	/**
+	 * @return int
+	 */
+	public function getVar(): int
+	{
+		return $this->var;
+	}
+
+	/**
+	 * @param int $var
+	 * @return self
+	 */
+	public function setVar(int $var): self
+	{
+		$this->var = $var;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setVar($data['var']);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'var' => $this->var
+		];
+	}
+}

--- a/tests/converter/fixtures/results/all_types_json_php_8_0_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_0_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
@@ -258,15 +258,15 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'string_array' => $this->string_array,
-			'mixed_array' => $this->mixed_array,
-			'null_array' => $this->null_array,
-			'unknown_array' => $this->unknown_array,
+			'string_array' => $this->stringArray,
+			'mixed_array' => $this->mixedArray,
+			'null_array' => $this->nullArray,
+			'unknown_array' => $this->unknownArray,
 			'boolean' => $this->boolean,
 			'float' => $this->float,
 			'int' => $this->int,
 			'null' => $this->null,
-			'nested_class' => $this->nested_class->toArray(),
+			'nested_class' => $this->nestedClass->toArray(),
 			'string' => $this->string
 		];
 	}

--- a/tests/converter/fixtures/results/all_types_json_php_8_0_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_0_with_to_array_method.txt
@@ -18,15 +18,15 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'string_array' => $this->string_array,
-			'mixed_array' => $this->mixed_array,
-			'null_array' => $this->null_array,
-			'unknown_array' => $this->unknown_array,
+			'string_array' => $this->stringArray,
+			'mixed_array' => $this->mixedArray,
+			'null_array' => $this->nullArray,
+			'unknown_array' => $this->unknownArray,
 			'boolean' => $this->boolean,
 			'float' => $this->float,
 			'int' => $this->int,
 			'null' => $this->null,
-			'nested_class' => $this->nested_class->toArray(),
+			'nested_class' => $this->nestedClass->toArray(),
 			'string' => $this->string
 		];
 	}

--- a/tests/converter/fixtures/results/all_types_json_php_8_0_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_0_with_to_array_method.txt
@@ -1,0 +1,53 @@
+<?php
+
+class RootObject
+{
+	/** @var string[] */
+	public array $stringArray;
+	/** @var (string|int|null)[] */
+	public array $mixedArray;
+	public array $nullArray;
+	public array $unknownArray;
+	public bool $boolean;
+	public float $float;
+	public int $int;
+	public null $null;
+	public NestedClass $nestedClass;
+	public string $string;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'string_array' => $this->string_array,
+			'mixed_array' => $this->mixed_array,
+			'null_array' => $this->null_array,
+			'unknown_array' => $this->unknown_array,
+			'boolean' => $this->boolean,
+			'float' => $this->float,
+			'int' => $this->int,
+			'null' => $this->null,
+			'nested_class' => $this->nested_class->toArray(),
+			'string' => $this->string
+		];
+	}
+}
+
+<?php
+
+class NestedClass
+{
+	public int $var;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'var' => $this->var
+		];
+	}
+}

--- a/tests/converter/fixtures/results/all_types_json_php_8_0_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_0_with_to_array_method.txt
@@ -15,9 +15,6 @@ class RootObject
 	public NestedClass $nestedClass;
 	public string $string;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -41,9 +38,6 @@ class NestedClass
 {
 	public int $var;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/all_types_json_php_8_1_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_1_with_from_json_and_to_array_methods.txt
@@ -31,9 +31,6 @@ class RootObject
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -64,9 +61,6 @@ class NestedClass
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/all_types_json_php_8_1_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_1_with_from_json_and_to_array_methods.txt
@@ -34,15 +34,15 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'string_array' => $this->string_array,
-			'mixed_array' => $this->mixed_array,
-			'null_array' => $this->null_array,
-			'unknown_array' => $this->unknown_array,
+			'string_array' => $this->stringArray,
+			'mixed_array' => $this->mixedArray,
+			'null_array' => $this->nullArray,
+			'unknown_array' => $this->unknownArray,
 			'boolean' => $this->boolean,
 			'float' => $this->float,
 			'int' => $this->int,
 			'null' => $this->null,
-			'nested_class' => $this->nested_class->toArray(),
+			'nested_class' => $this->nestedClass->toArray(),
 			'string' => $this->string
 		];
 	}

--- a/tests/converter/fixtures/results/all_types_json_php_8_1_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_1_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,76 @@
+<?php
+
+class RootObject
+{
+	/** @var string[] */
+	public array $stringArray;
+	/** @var (string|int|null)[] */
+	public array $mixedArray;
+	public array $nullArray;
+	public array $unknownArray;
+	public bool $boolean;
+	public float $float;
+	public int $int;
+	public null $null;
+	public NestedClass $nestedClass;
+	public string $string;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->stringArray = $data->string_array;
+		$instance->mixedArray = $data->mixed_array;
+		$instance->nullArray = $data->null_array;
+		$instance->unknownArray = $data->unknown_array;
+		$instance->boolean = $data->boolean;
+		$instance->float = $data->float;
+		$instance->int = $data->int;
+		$instance->null = $data->null ?? null;
+		$instance->nestedClass = NestedClass::fromJson($data->nested_class);
+		$instance->string = $data->string;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'string_array' => $this->string_array,
+			'mixed_array' => $this->mixed_array,
+			'null_array' => $this->null_array,
+			'unknown_array' => $this->unknown_array,
+			'boolean' => $this->boolean,
+			'float' => $this->float,
+			'int' => $this->int,
+			'null' => $this->null,
+			'nested_class' => $this->nested_class->toArray(),
+			'string' => $this->string
+		];
+	}
+}
+
+<?php
+
+class NestedClass
+{
+	public int $var;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->var = $data->var;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'var' => $this->var
+		];
+	}
+}

--- a/tests/converter/fixtures/results/all_types_json_php_8_1_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_1_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
@@ -1,0 +1,322 @@
+<?php
+
+class RootObject
+{
+	/**
+	 * @var string[]
+	 */
+	public array $stringArray;
+
+	/**
+	 * @var (string|int|null)[]
+	 */
+	public array $mixedArray;
+
+	/**
+	 * @var array
+	 */
+	public array $nullArray;
+
+	/**
+	 * @var array
+	 */
+	public array $unknownArray;
+
+	/**
+	 * @var bool
+	 */
+	public bool $boolean;
+
+	/**
+	 * @var float
+	 */
+	public float $float;
+
+	/**
+	 * @var int
+	 */
+	public int $int;
+
+	/**
+	 * @var |null
+	 */
+	public null $null;
+
+	/**
+	 * @var NestedClass
+	 */
+	public NestedClass $nestedClass;
+
+	/**
+	 * @var string
+	 */
+	public string $string;
+
+	/**
+	 * @return string[]
+	 */
+	public function getStringArray(): array
+	{
+		return $this->stringArray;
+	}
+
+	/**
+	 * @return (string|int|null)[]
+	 */
+	public function getMixedArray(): array
+	{
+		return $this->mixedArray;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getNullArray(): array
+	{
+		return $this->nullArray;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getUnknownArray(): array
+	{
+		return $this->unknownArray;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function getBoolean(): bool
+	{
+		return $this->boolean;
+	}
+
+	/**
+	 * @return float
+	 */
+	public function getFloat(): float
+	{
+		return $this->float;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getInt(): int
+	{
+		return $this->int;
+	}
+
+	/**
+	 * @return |null
+	 */
+	public function getNull(): null
+	{
+		return $this->null;
+	}
+
+	/**
+	 * @return NestedClass
+	 */
+	public function getNestedClass(): NestedClass
+	{
+		return $this->nestedClass;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getString(): string
+	{
+		return $this->string;
+	}
+
+	/**
+	 * @param string[] $stringArray
+	 * @return self
+	 */
+	public function setStringArray(array $stringArray): self
+	{
+		$this->stringArray = $stringArray;
+		return $this;
+	}
+
+	/**
+	 * @param (string|int|null)[] $mixedArray
+	 * @return self
+	 */
+	public function setMixedArray(array $mixedArray): self
+	{
+		$this->mixedArray = $mixedArray;
+		return $this;
+	}
+
+	/**
+	 * @param array $nullArray
+	 * @return self
+	 */
+	public function setNullArray(array $nullArray): self
+	{
+		$this->nullArray = $nullArray;
+		return $this;
+	}
+
+	/**
+	 * @param array $unknownArray
+	 * @return self
+	 */
+	public function setUnknownArray(array $unknownArray): self
+	{
+		$this->unknownArray = $unknownArray;
+		return $this;
+	}
+
+	/**
+	 * @param bool $boolean
+	 * @return self
+	 */
+	public function setBoolean(bool $boolean): self
+	{
+		$this->boolean = $boolean;
+		return $this;
+	}
+
+	/**
+	 * @param float $float
+	 * @return self
+	 */
+	public function setFloat(float $float): self
+	{
+		$this->float = $float;
+		return $this;
+	}
+
+	/**
+	 * @param int $int
+	 * @return self
+	 */
+	public function setInt(int $int): self
+	{
+		$this->int = $int;
+		return $this;
+	}
+
+	/**
+	 * @param |null $null
+	 * @return self
+	 */
+	public function setNull(null $null): self
+	{
+		$this->null = $null;
+		return $this;
+	}
+
+	/**
+	 * @param NestedClass $nestedClass
+	 * @return self
+	 */
+	public function setNestedClass(NestedClass $nestedClass): self
+	{
+		$this->nestedClass = $nestedClass;
+		return $this;
+	}
+
+	/**
+	 * @param string $string
+	 * @return self
+	 */
+	public function setString(string $string): self
+	{
+		$this->string = $string;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setStringArray($data['string_array']);
+		$instance->setMixedArray($data['mixed_array']);
+		$instance->setNullArray($data['null_array']);
+		$instance->setUnknownArray($data['unknown_array']);
+		$instance->setBoolean($data['boolean']);
+		$instance->setFloat($data['float']);
+		$instance->setInt($data['int']);
+		$instance->setNull($data['null'] ?? null);
+		$instance->setNestedClass(NestedClass::fromJson($data['nested_class']));
+		$instance->setString($data['string']);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'string_array' => $this->string_array,
+			'mixed_array' => $this->mixed_array,
+			'null_array' => $this->null_array,
+			'unknown_array' => $this->unknown_array,
+			'boolean' => $this->boolean,
+			'float' => $this->float,
+			'int' => $this->int,
+			'null' => $this->null,
+			'nested_class' => $this->nested_class->toArray(),
+			'string' => $this->string
+		];
+	}
+}
+
+<?php
+
+class NestedClass
+{
+	/**
+	 * @var int
+	 */
+	public int $var;
+
+	/**
+	 * @return int
+	 */
+	public function getVar(): int
+	{
+		return $this->var;
+	}
+
+	/**
+	 * @param int $var
+	 * @return self
+	 */
+	public function setVar(int $var): self
+	{
+		$this->var = $var;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setVar($data['var']);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'var' => $this->var
+		];
+	}
+}

--- a/tests/converter/fixtures/results/all_types_json_php_8_1_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_1_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
@@ -258,15 +258,15 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'string_array' => $this->string_array,
-			'mixed_array' => $this->mixed_array,
-			'null_array' => $this->null_array,
-			'unknown_array' => $this->unknown_array,
+			'string_array' => $this->stringArray,
+			'mixed_array' => $this->mixedArray,
+			'null_array' => $this->nullArray,
+			'unknown_array' => $this->unknownArray,
 			'boolean' => $this->boolean,
 			'float' => $this->float,
 			'int' => $this->int,
 			'null' => $this->null,
-			'nested_class' => $this->nested_class->toArray(),
+			'nested_class' => $this->nestedClass->toArray(),
 			'string' => $this->string
 		];
 	}

--- a/tests/converter/fixtures/results/all_types_json_php_8_1_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_1_with_to_array_method.txt
@@ -18,15 +18,15 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'string_array' => $this->string_array,
-			'mixed_array' => $this->mixed_array,
-			'null_array' => $this->null_array,
-			'unknown_array' => $this->unknown_array,
+			'string_array' => $this->stringArray,
+			'mixed_array' => $this->mixedArray,
+			'null_array' => $this->nullArray,
+			'unknown_array' => $this->unknownArray,
 			'boolean' => $this->boolean,
 			'float' => $this->float,
 			'int' => $this->int,
 			'null' => $this->null,
-			'nested_class' => $this->nested_class->toArray(),
+			'nested_class' => $this->nestedClass->toArray(),
 			'string' => $this->string
 		];
 	}

--- a/tests/converter/fixtures/results/all_types_json_php_8_1_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_1_with_to_array_method.txt
@@ -1,0 +1,53 @@
+<?php
+
+class RootObject
+{
+	/** @var string[] */
+	public array $stringArray;
+	/** @var (string|int|null)[] */
+	public array $mixedArray;
+	public array $nullArray;
+	public array $unknownArray;
+	public bool $boolean;
+	public float $float;
+	public int $int;
+	public null $null;
+	public NestedClass $nestedClass;
+	public string $string;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'string_array' => $this->string_array,
+			'mixed_array' => $this->mixed_array,
+			'null_array' => $this->null_array,
+			'unknown_array' => $this->unknown_array,
+			'boolean' => $this->boolean,
+			'float' => $this->float,
+			'int' => $this->int,
+			'null' => $this->null,
+			'nested_class' => $this->nested_class->toArray(),
+			'string' => $this->string
+		];
+	}
+}
+
+<?php
+
+class NestedClass
+{
+	public int $var;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'var' => $this->var
+		];
+	}
+}

--- a/tests/converter/fixtures/results/all_types_json_php_8_1_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_1_with_to_array_method.txt
@@ -15,9 +15,6 @@ class RootObject
 	public NestedClass $nestedClass;
 	public string $string;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -41,9 +38,6 @@ class NestedClass
 {
 	public int $var;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/all_types_json_php_8_2_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_2_with_from_json_and_to_array_methods.txt
@@ -31,9 +31,6 @@ class RootObject
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -64,9 +61,6 @@ class NestedClass
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/all_types_json_php_8_2_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_2_with_from_json_and_to_array_methods.txt
@@ -34,15 +34,15 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'string_array' => $this->string_array,
-			'mixed_array' => $this->mixed_array,
-			'null_array' => $this->null_array,
-			'unknown_array' => $this->unknown_array,
+			'string_array' => $this->stringArray,
+			'mixed_array' => $this->mixedArray,
+			'null_array' => $this->nullArray,
+			'unknown_array' => $this->unknownArray,
 			'boolean' => $this->boolean,
 			'float' => $this->float,
 			'int' => $this->int,
 			'null' => $this->null,
-			'nested_class' => $this->nested_class->toArray(),
+			'nested_class' => $this->nestedClass->toArray(),
 			'string' => $this->string
 		];
 	}

--- a/tests/converter/fixtures/results/all_types_json_php_8_2_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_2_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,76 @@
+<?php
+
+class RootObject
+{
+	/** @var string[] */
+	public array $stringArray;
+	/** @var (string|int|null)[] */
+	public array $mixedArray;
+	public array $nullArray;
+	public array $unknownArray;
+	public bool $boolean;
+	public float $float;
+	public int $int;
+	public null $null;
+	public NestedClass $nestedClass;
+	public string $string;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->stringArray = $data->string_array;
+		$instance->mixedArray = $data->mixed_array;
+		$instance->nullArray = $data->null_array;
+		$instance->unknownArray = $data->unknown_array;
+		$instance->boolean = $data->boolean;
+		$instance->float = $data->float;
+		$instance->int = $data->int;
+		$instance->null = $data->null ?? null;
+		$instance->nestedClass = NestedClass::fromJson($data->nested_class);
+		$instance->string = $data->string;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'string_array' => $this->string_array,
+			'mixed_array' => $this->mixed_array,
+			'null_array' => $this->null_array,
+			'unknown_array' => $this->unknown_array,
+			'boolean' => $this->boolean,
+			'float' => $this->float,
+			'int' => $this->int,
+			'null' => $this->null,
+			'nested_class' => $this->nested_class->toArray(),
+			'string' => $this->string
+		];
+	}
+}
+
+<?php
+
+class NestedClass
+{
+	public int $var;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->var = $data->var;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'var' => $this->var
+		];
+	}
+}

--- a/tests/converter/fixtures/results/all_types_json_php_8_2_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_2_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
@@ -1,0 +1,322 @@
+<?php
+
+class RootObject
+{
+	/**
+	 * @var string[]
+	 */
+	public array $stringArray;
+
+	/**
+	 * @var (string|int|null)[]
+	 */
+	public array $mixedArray;
+
+	/**
+	 * @var array
+	 */
+	public array $nullArray;
+
+	/**
+	 * @var array
+	 */
+	public array $unknownArray;
+
+	/**
+	 * @var bool
+	 */
+	public bool $boolean;
+
+	/**
+	 * @var float
+	 */
+	public float $float;
+
+	/**
+	 * @var int
+	 */
+	public int $int;
+
+	/**
+	 * @var |null
+	 */
+	public null $null;
+
+	/**
+	 * @var NestedClass
+	 */
+	public NestedClass $nestedClass;
+
+	/**
+	 * @var string
+	 */
+	public string $string;
+
+	/**
+	 * @return string[]
+	 */
+	public function getStringArray(): array
+	{
+		return $this->stringArray;
+	}
+
+	/**
+	 * @return (string|int|null)[]
+	 */
+	public function getMixedArray(): array
+	{
+		return $this->mixedArray;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getNullArray(): array
+	{
+		return $this->nullArray;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getUnknownArray(): array
+	{
+		return $this->unknownArray;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function getBoolean(): bool
+	{
+		return $this->boolean;
+	}
+
+	/**
+	 * @return float
+	 */
+	public function getFloat(): float
+	{
+		return $this->float;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getInt(): int
+	{
+		return $this->int;
+	}
+
+	/**
+	 * @return |null
+	 */
+	public function getNull(): null
+	{
+		return $this->null;
+	}
+
+	/**
+	 * @return NestedClass
+	 */
+	public function getNestedClass(): NestedClass
+	{
+		return $this->nestedClass;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getString(): string
+	{
+		return $this->string;
+	}
+
+	/**
+	 * @param string[] $stringArray
+	 * @return self
+	 */
+	public function setStringArray(array $stringArray): self
+	{
+		$this->stringArray = $stringArray;
+		return $this;
+	}
+
+	/**
+	 * @param (string|int|null)[] $mixedArray
+	 * @return self
+	 */
+	public function setMixedArray(array $mixedArray): self
+	{
+		$this->mixedArray = $mixedArray;
+		return $this;
+	}
+
+	/**
+	 * @param array $nullArray
+	 * @return self
+	 */
+	public function setNullArray(array $nullArray): self
+	{
+		$this->nullArray = $nullArray;
+		return $this;
+	}
+
+	/**
+	 * @param array $unknownArray
+	 * @return self
+	 */
+	public function setUnknownArray(array $unknownArray): self
+	{
+		$this->unknownArray = $unknownArray;
+		return $this;
+	}
+
+	/**
+	 * @param bool $boolean
+	 * @return self
+	 */
+	public function setBoolean(bool $boolean): self
+	{
+		$this->boolean = $boolean;
+		return $this;
+	}
+
+	/**
+	 * @param float $float
+	 * @return self
+	 */
+	public function setFloat(float $float): self
+	{
+		$this->float = $float;
+		return $this;
+	}
+
+	/**
+	 * @param int $int
+	 * @return self
+	 */
+	public function setInt(int $int): self
+	{
+		$this->int = $int;
+		return $this;
+	}
+
+	/**
+	 * @param |null $null
+	 * @return self
+	 */
+	public function setNull(null $null): self
+	{
+		$this->null = $null;
+		return $this;
+	}
+
+	/**
+	 * @param NestedClass $nestedClass
+	 * @return self
+	 */
+	public function setNestedClass(NestedClass $nestedClass): self
+	{
+		$this->nestedClass = $nestedClass;
+		return $this;
+	}
+
+	/**
+	 * @param string $string
+	 * @return self
+	 */
+	public function setString(string $string): self
+	{
+		$this->string = $string;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setStringArray($data['string_array']);
+		$instance->setMixedArray($data['mixed_array']);
+		$instance->setNullArray($data['null_array']);
+		$instance->setUnknownArray($data['unknown_array']);
+		$instance->setBoolean($data['boolean']);
+		$instance->setFloat($data['float']);
+		$instance->setInt($data['int']);
+		$instance->setNull($data['null'] ?? null);
+		$instance->setNestedClass(NestedClass::fromJson($data['nested_class']));
+		$instance->setString($data['string']);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'string_array' => $this->string_array,
+			'mixed_array' => $this->mixed_array,
+			'null_array' => $this->null_array,
+			'unknown_array' => $this->unknown_array,
+			'boolean' => $this->boolean,
+			'float' => $this->float,
+			'int' => $this->int,
+			'null' => $this->null,
+			'nested_class' => $this->nested_class->toArray(),
+			'string' => $this->string
+		];
+	}
+}
+
+<?php
+
+class NestedClass
+{
+	/**
+	 * @var int
+	 */
+	public int $var;
+
+	/**
+	 * @return int
+	 */
+	public function getVar(): int
+	{
+		return $this->var;
+	}
+
+	/**
+	 * @param int $var
+	 * @return self
+	 */
+	public function setVar(int $var): self
+	{
+		$this->var = $var;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setVar($data['var']);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'var' => $this->var
+		];
+	}
+}

--- a/tests/converter/fixtures/results/all_types_json_php_8_2_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_2_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
@@ -258,15 +258,15 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'string_array' => $this->string_array,
-			'mixed_array' => $this->mixed_array,
-			'null_array' => $this->null_array,
-			'unknown_array' => $this->unknown_array,
+			'string_array' => $this->stringArray,
+			'mixed_array' => $this->mixedArray,
+			'null_array' => $this->nullArray,
+			'unknown_array' => $this->unknownArray,
 			'boolean' => $this->boolean,
 			'float' => $this->float,
 			'int' => $this->int,
 			'null' => $this->null,
-			'nested_class' => $this->nested_class->toArray(),
+			'nested_class' => $this->nestedClass->toArray(),
 			'string' => $this->string
 		];
 	}

--- a/tests/converter/fixtures/results/all_types_json_php_8_2_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_2_with_to_array_method.txt
@@ -18,15 +18,15 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'string_array' => $this->string_array,
-			'mixed_array' => $this->mixed_array,
-			'null_array' => $this->null_array,
-			'unknown_array' => $this->unknown_array,
+			'string_array' => $this->stringArray,
+			'mixed_array' => $this->mixedArray,
+			'null_array' => $this->nullArray,
+			'unknown_array' => $this->unknownArray,
 			'boolean' => $this->boolean,
 			'float' => $this->float,
 			'int' => $this->int,
 			'null' => $this->null,
-			'nested_class' => $this->nested_class->toArray(),
+			'nested_class' => $this->nestedClass->toArray(),
 			'string' => $this->string
 		];
 	}

--- a/tests/converter/fixtures/results/all_types_json_php_8_2_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_2_with_to_array_method.txt
@@ -1,0 +1,53 @@
+<?php
+
+class RootObject
+{
+	/** @var string[] */
+	public array $stringArray;
+	/** @var (string|int|null)[] */
+	public array $mixedArray;
+	public array $nullArray;
+	public array $unknownArray;
+	public bool $boolean;
+	public float $float;
+	public int $int;
+	public null $null;
+	public NestedClass $nestedClass;
+	public string $string;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'string_array' => $this->string_array,
+			'mixed_array' => $this->mixed_array,
+			'null_array' => $this->null_array,
+			'unknown_array' => $this->unknown_array,
+			'boolean' => $this->boolean,
+			'float' => $this->float,
+			'int' => $this->int,
+			'null' => $this->null,
+			'nested_class' => $this->nested_class->toArray(),
+			'string' => $this->string
+		];
+	}
+}
+
+<?php
+
+class NestedClass
+{
+	public int $var;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'var' => $this->var
+		];
+	}
+}

--- a/tests/converter/fixtures/results/all_types_json_php_8_2_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_2_with_to_array_method.txt
@@ -15,9 +15,6 @@ class RootObject
 	public NestedClass $nestedClass;
 	public string $string;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -41,9 +38,6 @@ class NestedClass
 {
 	public int $var;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/all_types_json_php_8_3_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_3_with_from_json_and_to_array_methods.txt
@@ -31,9 +31,6 @@ class RootObject
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -64,9 +61,6 @@ class NestedClass
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/all_types_json_php_8_3_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_3_with_from_json_and_to_array_methods.txt
@@ -34,15 +34,15 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'string_array' => $this->string_array,
-			'mixed_array' => $this->mixed_array,
-			'null_array' => $this->null_array,
-			'unknown_array' => $this->unknown_array,
+			'string_array' => $this->stringArray,
+			'mixed_array' => $this->mixedArray,
+			'null_array' => $this->nullArray,
+			'unknown_array' => $this->unknownArray,
 			'boolean' => $this->boolean,
 			'float' => $this->float,
 			'int' => $this->int,
 			'null' => $this->null,
-			'nested_class' => $this->nested_class->toArray(),
+			'nested_class' => $this->nestedClass->toArray(),
 			'string' => $this->string
 		];
 	}

--- a/tests/converter/fixtures/results/all_types_json_php_8_3_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_3_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,76 @@
+<?php
+
+class RootObject
+{
+	/** @var string[] */
+	public array $stringArray;
+	/** @var (string|int|null)[] */
+	public array $mixedArray;
+	public array $nullArray;
+	public array $unknownArray;
+	public bool $boolean;
+	public float $float;
+	public int $int;
+	public null $null;
+	public NestedClass $nestedClass;
+	public string $string;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->stringArray = $data->string_array;
+		$instance->mixedArray = $data->mixed_array;
+		$instance->nullArray = $data->null_array;
+		$instance->unknownArray = $data->unknown_array;
+		$instance->boolean = $data->boolean;
+		$instance->float = $data->float;
+		$instance->int = $data->int;
+		$instance->null = $data->null ?? null;
+		$instance->nestedClass = NestedClass::fromJson($data->nested_class);
+		$instance->string = $data->string;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'string_array' => $this->string_array,
+			'mixed_array' => $this->mixed_array,
+			'null_array' => $this->null_array,
+			'unknown_array' => $this->unknown_array,
+			'boolean' => $this->boolean,
+			'float' => $this->float,
+			'int' => $this->int,
+			'null' => $this->null,
+			'nested_class' => $this->nested_class->toArray(),
+			'string' => $this->string
+		];
+	}
+}
+
+<?php
+
+class NestedClass
+{
+	public int $var;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->var = $data->var;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'var' => $this->var
+		];
+	}
+}

--- a/tests/converter/fixtures/results/all_types_json_php_8_3_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_3_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
@@ -1,0 +1,322 @@
+<?php
+
+class RootObject
+{
+	/**
+	 * @var string[]
+	 */
+	public array $stringArray;
+
+	/**
+	 * @var (string|int|null)[]
+	 */
+	public array $mixedArray;
+
+	/**
+	 * @var array
+	 */
+	public array $nullArray;
+
+	/**
+	 * @var array
+	 */
+	public array $unknownArray;
+
+	/**
+	 * @var bool
+	 */
+	public bool $boolean;
+
+	/**
+	 * @var float
+	 */
+	public float $float;
+
+	/**
+	 * @var int
+	 */
+	public int $int;
+
+	/**
+	 * @var |null
+	 */
+	public null $null;
+
+	/**
+	 * @var NestedClass
+	 */
+	public NestedClass $nestedClass;
+
+	/**
+	 * @var string
+	 */
+	public string $string;
+
+	/**
+	 * @return string[]
+	 */
+	public function getStringArray(): array
+	{
+		return $this->stringArray;
+	}
+
+	/**
+	 * @return (string|int|null)[]
+	 */
+	public function getMixedArray(): array
+	{
+		return $this->mixedArray;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getNullArray(): array
+	{
+		return $this->nullArray;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getUnknownArray(): array
+	{
+		return $this->unknownArray;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function getBoolean(): bool
+	{
+		return $this->boolean;
+	}
+
+	/**
+	 * @return float
+	 */
+	public function getFloat(): float
+	{
+		return $this->float;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getInt(): int
+	{
+		return $this->int;
+	}
+
+	/**
+	 * @return |null
+	 */
+	public function getNull(): null
+	{
+		return $this->null;
+	}
+
+	/**
+	 * @return NestedClass
+	 */
+	public function getNestedClass(): NestedClass
+	{
+		return $this->nestedClass;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getString(): string
+	{
+		return $this->string;
+	}
+
+	/**
+	 * @param string[] $stringArray
+	 * @return self
+	 */
+	public function setStringArray(array $stringArray): self
+	{
+		$this->stringArray = $stringArray;
+		return $this;
+	}
+
+	/**
+	 * @param (string|int|null)[] $mixedArray
+	 * @return self
+	 */
+	public function setMixedArray(array $mixedArray): self
+	{
+		$this->mixedArray = $mixedArray;
+		return $this;
+	}
+
+	/**
+	 * @param array $nullArray
+	 * @return self
+	 */
+	public function setNullArray(array $nullArray): self
+	{
+		$this->nullArray = $nullArray;
+		return $this;
+	}
+
+	/**
+	 * @param array $unknownArray
+	 * @return self
+	 */
+	public function setUnknownArray(array $unknownArray): self
+	{
+		$this->unknownArray = $unknownArray;
+		return $this;
+	}
+
+	/**
+	 * @param bool $boolean
+	 * @return self
+	 */
+	public function setBoolean(bool $boolean): self
+	{
+		$this->boolean = $boolean;
+		return $this;
+	}
+
+	/**
+	 * @param float $float
+	 * @return self
+	 */
+	public function setFloat(float $float): self
+	{
+		$this->float = $float;
+		return $this;
+	}
+
+	/**
+	 * @param int $int
+	 * @return self
+	 */
+	public function setInt(int $int): self
+	{
+		$this->int = $int;
+		return $this;
+	}
+
+	/**
+	 * @param |null $null
+	 * @return self
+	 */
+	public function setNull(null $null): self
+	{
+		$this->null = $null;
+		return $this;
+	}
+
+	/**
+	 * @param NestedClass $nestedClass
+	 * @return self
+	 */
+	public function setNestedClass(NestedClass $nestedClass): self
+	{
+		$this->nestedClass = $nestedClass;
+		return $this;
+	}
+
+	/**
+	 * @param string $string
+	 * @return self
+	 */
+	public function setString(string $string): self
+	{
+		$this->string = $string;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setStringArray($data['string_array']);
+		$instance->setMixedArray($data['mixed_array']);
+		$instance->setNullArray($data['null_array']);
+		$instance->setUnknownArray($data['unknown_array']);
+		$instance->setBoolean($data['boolean']);
+		$instance->setFloat($data['float']);
+		$instance->setInt($data['int']);
+		$instance->setNull($data['null'] ?? null);
+		$instance->setNestedClass(NestedClass::fromJson($data['nested_class']));
+		$instance->setString($data['string']);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'string_array' => $this->string_array,
+			'mixed_array' => $this->mixed_array,
+			'null_array' => $this->null_array,
+			'unknown_array' => $this->unknown_array,
+			'boolean' => $this->boolean,
+			'float' => $this->float,
+			'int' => $this->int,
+			'null' => $this->null,
+			'nested_class' => $this->nested_class->toArray(),
+			'string' => $this->string
+		];
+	}
+}
+
+<?php
+
+class NestedClass
+{
+	/**
+	 * @var int
+	 */
+	public int $var;
+
+	/**
+	 * @return int
+	 */
+	public function getVar(): int
+	{
+		return $this->var;
+	}
+
+	/**
+	 * @param int $var
+	 * @return self
+	 */
+	public function setVar(int $var): self
+	{
+		$this->var = $var;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setVar($data['var']);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'var' => $this->var
+		];
+	}
+}

--- a/tests/converter/fixtures/results/all_types_json_php_8_3_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_3_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
@@ -258,15 +258,15 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'string_array' => $this->string_array,
-			'mixed_array' => $this->mixed_array,
-			'null_array' => $this->null_array,
-			'unknown_array' => $this->unknown_array,
+			'string_array' => $this->stringArray,
+			'mixed_array' => $this->mixedArray,
+			'null_array' => $this->nullArray,
+			'unknown_array' => $this->unknownArray,
 			'boolean' => $this->boolean,
 			'float' => $this->float,
 			'int' => $this->int,
 			'null' => $this->null,
-			'nested_class' => $this->nested_class->toArray(),
+			'nested_class' => $this->nestedClass->toArray(),
 			'string' => $this->string
 		];
 	}

--- a/tests/converter/fixtures/results/all_types_json_php_8_3_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_3_with_to_array_method.txt
@@ -18,15 +18,15 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'string_array' => $this->string_array,
-			'mixed_array' => $this->mixed_array,
-			'null_array' => $this->null_array,
-			'unknown_array' => $this->unknown_array,
+			'string_array' => $this->stringArray,
+			'mixed_array' => $this->mixedArray,
+			'null_array' => $this->nullArray,
+			'unknown_array' => $this->unknownArray,
 			'boolean' => $this->boolean,
 			'float' => $this->float,
 			'int' => $this->int,
 			'null' => $this->null,
-			'nested_class' => $this->nested_class->toArray(),
+			'nested_class' => $this->nestedClass->toArray(),
 			'string' => $this->string
 		];
 	}

--- a/tests/converter/fixtures/results/all_types_json_php_8_3_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_3_with_to_array_method.txt
@@ -1,0 +1,53 @@
+<?php
+
+class RootObject
+{
+	/** @var string[] */
+	public array $stringArray;
+	/** @var (string|int|null)[] */
+	public array $mixedArray;
+	public array $nullArray;
+	public array $unknownArray;
+	public bool $boolean;
+	public float $float;
+	public int $int;
+	public null $null;
+	public NestedClass $nestedClass;
+	public string $string;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'string_array' => $this->string_array,
+			'mixed_array' => $this->mixed_array,
+			'null_array' => $this->null_array,
+			'unknown_array' => $this->unknown_array,
+			'boolean' => $this->boolean,
+			'float' => $this->float,
+			'int' => $this->int,
+			'null' => $this->null,
+			'nested_class' => $this->nested_class->toArray(),
+			'string' => $this->string
+		];
+	}
+}
+
+<?php
+
+class NestedClass
+{
+	public int $var;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'var' => $this->var
+		];
+	}
+}

--- a/tests/converter/fixtures/results/all_types_json_php_8_3_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_3_with_to_array_method.txt
@@ -15,9 +15,6 @@ class RootObject
 	public NestedClass $nestedClass;
 	public string $string;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -41,9 +38,6 @@ class NestedClass
 {
 	public int $var;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_7_3_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_7_3_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,88 @@
+<?php
+
+class RootObject
+{
+	/** @var SimpleNesting[] */
+	public $simpleNesting;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->simpleNesting = array_map(static function($data) {
+			return SimpleNesting::fromJson($data);
+		}, $data->simple_nesting);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'simple_nesting' => array_map(function($item) {
+				    return $item->toArray();
+			}, $this->simple_nesting)
+		];
+	}
+}
+
+<?php
+
+class SimpleNesting
+{
+	public $alwaysPresent;
+	public $string;
+	public $object;
+	public $number;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->alwaysPresent = $data->always_present;
+		$instance->string = $data->string ?? null;
+		$instance->object = ($data->object ?? null) !== null ? Object::fromJson($data->object) : null;
+		$instance->number = $data->number ?? null;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'always_present' => $this->always_present,
+			'string' => $this->string,
+			'object' => $this->object !== null ? $this->object->toArray() : null,
+			'number' => $this->number
+		];
+	}
+}
+
+<?php
+
+class Object
+{
+	public $test;
+	public $anotherTest;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->test = $data->test ?? null;
+		$instance->anotherTest = $data->another_test ?? null;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test,
+			'another_test' => $this->another_test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_7_3_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_7_3_with_from_json_and_to_array_methods.txt
@@ -17,9 +17,9 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'simple_nesting' => array_map(function($item) {
+			'simple_nesting' => array_map(static function($item) {
 				    return $item->toArray();
-			}, $this->simple_nesting)
+			}, $this->simpleNesting)
 		];
 	}
 }
@@ -46,7 +46,7 @@ class SimpleNesting
 	public function toArray(): array
 	{
 		return [
-			'always_present' => $this->always_present,
+			'always_present' => $this->alwaysPresent,
 			'string' => $this->string,
 			'object' => $this->object !== null ? $this->object->toArray() : null,
 			'number' => $this->number
@@ -73,7 +73,7 @@ class Object
 	{
 		return [
 			'test' => $this->test,
-			'another_test' => $this->another_test
+			'another_test' => $this->anotherTest
 		];
 	}
 }

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_7_3_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_7_3_with_from_json_and_to_array_methods.txt
@@ -14,9 +14,6 @@ class RootObject
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -46,9 +43,6 @@ class SimpleNesting
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -75,9 +69,6 @@ class Object
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_7_3_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_7_3_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
@@ -44,9 +44,9 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'simple_nesting' => array_map(function($item) {
+			'simple_nesting' => array_map(static function($item) {
 				    return $item->toArray();
-			}, $this->simple_nesting)
+			}, $this->simpleNesting)
 		];
 	}
 }
@@ -167,7 +167,7 @@ class SimpleNesting
 	public function toArray(): array
 	{
 		return [
-			'always_present' => $this->always_present,
+			'always_present' => $this->alwaysPresent,
 			'string' => $this->string,
 			'object' => $this->object !== null ? $this->object->toArray() : null,
 			'number' => $this->number
@@ -244,7 +244,7 @@ class Object
 	{
 		return [
 			'test' => $this->test,
-			'another_test' => $this->another_test
+			'another_test' => $this->anotherTest
 		];
 	}
 }

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_7_3_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_7_3_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
@@ -1,0 +1,250 @@
+<?php
+
+class RootObject
+{
+	/**
+	 * @var SimpleNesting[]
+	 */
+	public $simpleNesting;
+
+	/**
+	 * @return SimpleNesting[]
+	 */
+	public function getSimpleNesting(): array
+	{
+		return $this->simpleNesting;
+	}
+
+	/**
+	 * @param SimpleNesting[] $simpleNesting
+	 * @return self
+	 */
+	public function setSimpleNesting(array $simpleNesting): self
+	{
+		$this->simpleNesting = $simpleNesting;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setSimpleNesting(array_map(static function($data) {
+			return SimpleNesting::fromJson($data);
+		}, $data['simple_nesting']));
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'simple_nesting' => array_map(function($item) {
+				    return $item->toArray();
+			}, $this->simple_nesting)
+		];
+	}
+}
+
+<?php
+
+class SimpleNesting
+{
+	/**
+	 * @var float
+	 */
+	public $alwaysPresent;
+
+	/**
+	 * @var string|null
+	 */
+	public $string;
+
+	/**
+	 * @var Object|null
+	 */
+	public $object;
+
+	/**
+	 * @var int|null
+	 */
+	public $number;
+
+	/**
+	 * @return float
+	 */
+	public function getAlwaysPresent(): float
+	{
+		return $this->alwaysPresent;
+	}
+
+	/**
+	 * @return string|null
+	 */
+	public function getString(): ?string
+	{
+		return $this->string;
+	}
+
+	/**
+	 * @return Object|null
+	 */
+	public function getObject(): ?Object
+	{
+		return $this->object;
+	}
+
+	/**
+	 * @return int|null
+	 */
+	public function getNumber(): ?int
+	{
+		return $this->number;
+	}
+
+	/**
+	 * @param float $alwaysPresent
+	 * @return self
+	 */
+	public function setAlwaysPresent(float $alwaysPresent): self
+	{
+		$this->alwaysPresent = $alwaysPresent;
+		return $this;
+	}
+
+	/**
+	 * @param string|null $string
+	 * @return self
+	 */
+	public function setString(?string $string): self
+	{
+		$this->string = $string;
+		return $this;
+	}
+
+	/**
+	 * @param Object|null $object
+	 * @return self
+	 */
+	public function setObject(?Object $object): self
+	{
+		$this->object = $object;
+		return $this;
+	}
+
+	/**
+	 * @param int|null $number
+	 * @return self
+	 */
+	public function setNumber(?int $number): self
+	{
+		$this->number = $number;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setAlwaysPresent($data['always_present']);
+		$instance->setString($data['string'] ?? null);
+		$instance->setObject(($data['object'] ?? null) !== null ? Object::fromJson($data['object']) : null);
+		$instance->setNumber($data['number'] ?? null);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'always_present' => $this->always_present,
+			'string' => $this->string,
+			'object' => $this->object !== null ? $this->object->toArray() : null,
+			'number' => $this->number
+		];
+	}
+}
+
+<?php
+
+class Object
+{
+	/**
+	 * @var int|null
+	 */
+	public $test;
+
+	/**
+	 * @var int|null
+	 */
+	public $anotherTest;
+
+	/**
+	 * @return int|null
+	 */
+	public function getTest(): ?int
+	{
+		return $this->test;
+	}
+
+	/**
+	 * @return int|null
+	 */
+	public function getAnotherTest(): ?int
+	{
+		return $this->anotherTest;
+	}
+
+	/**
+	 * @param int|null $test
+	 * @return self
+	 */
+	public function setTest(?int $test): self
+	{
+		$this->test = $test;
+		return $this;
+	}
+
+	/**
+	 * @param int|null $anotherTest
+	 * @return self
+	 */
+	public function setAnotherTest(?int $anotherTest): self
+	{
+		$this->anotherTest = $anotherTest;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setTest($data['test'] ?? null);
+		$instance->setAnotherTest($data['another_test'] ?? null);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test,
+			'another_test' => $this->another_test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_7_3_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_7_3_with_to_array_method.txt
@@ -1,0 +1,61 @@
+<?php
+
+class RootObject
+{
+	/** @var SimpleNesting[] */
+	public $simpleNesting;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'simple_nesting' => array_map(function($item) {
+				    return $item->toArray();
+			}, $this->simple_nesting)
+		];
+	}
+}
+
+<?php
+
+class SimpleNesting
+{
+	public $alwaysPresent;
+	public $string;
+	public $object;
+	public $number;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'always_present' => $this->always_present,
+			'string' => $this->string,
+			'object' => $this->object !== null ? $this->object->toArray() : null,
+			'number' => $this->number
+		];
+	}
+}
+
+<?php
+
+class Object
+{
+	public $test;
+	public $anotherTest;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test,
+			'another_test' => $this->another_test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_7_3_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_7_3_with_to_array_method.txt
@@ -5,9 +5,6 @@ class RootObject
 	/** @var SimpleNesting[] */
 	public $simpleNesting;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -27,9 +24,6 @@ class SimpleNesting
 	public $object;
 	public $number;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -48,9 +42,6 @@ class Object
 	public $test;
 	public $anotherTest;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_7_3_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_7_3_with_to_array_method.txt
@@ -8,9 +8,9 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'simple_nesting' => array_map(function($item) {
+			'simple_nesting' => array_map(static function($item) {
 				    return $item->toArray();
-			}, $this->simple_nesting)
+			}, $this->simpleNesting)
 		];
 	}
 }
@@ -27,7 +27,7 @@ class SimpleNesting
 	public function toArray(): array
 	{
 		return [
-			'always_present' => $this->always_present,
+			'always_present' => $this->alwaysPresent,
 			'string' => $this->string,
 			'object' => $this->object !== null ? $this->object->toArray() : null,
 			'number' => $this->number
@@ -46,7 +46,7 @@ class Object
 	{
 		return [
 			'test' => $this->test,
-			'another_test' => $this->another_test
+			'another_test' => $this->anotherTest
 		];
 	}
 }

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_7_4_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_7_4_with_from_json_and_to_array_methods.txt
@@ -17,9 +17,9 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'simple_nesting' => array_map(function($item) {
+			'simple_nesting' => array_map(static function($item) {
 				    return $item->toArray();
-			}, $this->simple_nesting)
+			}, $this->simpleNesting)
 		];
 	}
 }
@@ -46,7 +46,7 @@ class SimpleNesting
 	public function toArray(): array
 	{
 		return [
-			'always_present' => $this->always_present,
+			'always_present' => $this->alwaysPresent,
 			'string' => $this->string,
 			'object' => $this->object !== null ? $this->object->toArray() : null,
 			'number' => $this->number
@@ -73,7 +73,7 @@ class Object
 	{
 		return [
 			'test' => $this->test,
-			'another_test' => $this->another_test
+			'another_test' => $this->anotherTest
 		];
 	}
 }

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_7_4_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_7_4_with_from_json_and_to_array_methods.txt
@@ -14,9 +14,6 @@ class RootObject
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -46,9 +43,6 @@ class SimpleNesting
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -75,9 +69,6 @@ class Object
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_7_4_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_7_4_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,88 @@
+<?php
+
+class RootObject
+{
+	/** @var SimpleNesting[] */
+	public array $simpleNesting;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->simpleNesting = array_map(static function($data) {
+			return SimpleNesting::fromJson($data);
+		}, $data->simple_nesting);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'simple_nesting' => array_map(function($item) {
+				    return $item->toArray();
+			}, $this->simple_nesting)
+		];
+	}
+}
+
+<?php
+
+class SimpleNesting
+{
+	public float $alwaysPresent;
+	public ?string $string;
+	public ?Object $object;
+	public ?int $number;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->alwaysPresent = $data->always_present;
+		$instance->string = $data->string ?? null;
+		$instance->object = ($data->object ?? null) !== null ? Object::fromJson($data->object) : null;
+		$instance->number = $data->number ?? null;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'always_present' => $this->always_present,
+			'string' => $this->string,
+			'object' => $this->object !== null ? $this->object->toArray() : null,
+			'number' => $this->number
+		];
+	}
+}
+
+<?php
+
+class Object
+{
+	public ?int $test;
+	public ?int $anotherTest;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->test = $data->test ?? null;
+		$instance->anotherTest = $data->another_test ?? null;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test,
+			'another_test' => $this->another_test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_7_4_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_7_4_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
@@ -1,0 +1,250 @@
+<?php
+
+class RootObject
+{
+	/**
+	 * @var SimpleNesting[]
+	 */
+	public array $simpleNesting;
+
+	/**
+	 * @return SimpleNesting[]
+	 */
+	public function getSimpleNesting(): array
+	{
+		return $this->simpleNesting;
+	}
+
+	/**
+	 * @param SimpleNesting[] $simpleNesting
+	 * @return self
+	 */
+	public function setSimpleNesting(array $simpleNesting): self
+	{
+		$this->simpleNesting = $simpleNesting;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setSimpleNesting(array_map(static function($data) {
+			return SimpleNesting::fromJson($data);
+		}, $data['simple_nesting']));
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'simple_nesting' => array_map(function($item) {
+				    return $item->toArray();
+			}, $this->simple_nesting)
+		];
+	}
+}
+
+<?php
+
+class SimpleNesting
+{
+	/**
+	 * @var float
+	 */
+	public float $alwaysPresent;
+
+	/**
+	 * @var string|null
+	 */
+	public ?string $string;
+
+	/**
+	 * @var Object|null
+	 */
+	public ?Object $object;
+
+	/**
+	 * @var int|null
+	 */
+	public ?int $number;
+
+	/**
+	 * @return float
+	 */
+	public function getAlwaysPresent(): float
+	{
+		return $this->alwaysPresent;
+	}
+
+	/**
+	 * @return string|null
+	 */
+	public function getString(): ?string
+	{
+		return $this->string;
+	}
+
+	/**
+	 * @return Object|null
+	 */
+	public function getObject(): ?Object
+	{
+		return $this->object;
+	}
+
+	/**
+	 * @return int|null
+	 */
+	public function getNumber(): ?int
+	{
+		return $this->number;
+	}
+
+	/**
+	 * @param float $alwaysPresent
+	 * @return self
+	 */
+	public function setAlwaysPresent(float $alwaysPresent): self
+	{
+		$this->alwaysPresent = $alwaysPresent;
+		return $this;
+	}
+
+	/**
+	 * @param string|null $string
+	 * @return self
+	 */
+	public function setString(?string $string): self
+	{
+		$this->string = $string;
+		return $this;
+	}
+
+	/**
+	 * @param Object|null $object
+	 * @return self
+	 */
+	public function setObject(?Object $object): self
+	{
+		$this->object = $object;
+		return $this;
+	}
+
+	/**
+	 * @param int|null $number
+	 * @return self
+	 */
+	public function setNumber(?int $number): self
+	{
+		$this->number = $number;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setAlwaysPresent($data['always_present']);
+		$instance->setString($data['string'] ?? null);
+		$instance->setObject(($data['object'] ?? null) !== null ? Object::fromJson($data['object']) : null);
+		$instance->setNumber($data['number'] ?? null);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'always_present' => $this->always_present,
+			'string' => $this->string,
+			'object' => $this->object !== null ? $this->object->toArray() : null,
+			'number' => $this->number
+		];
+	}
+}
+
+<?php
+
+class Object
+{
+	/**
+	 * @var int|null
+	 */
+	public ?int $test;
+
+	/**
+	 * @var int|null
+	 */
+	public ?int $anotherTest;
+
+	/**
+	 * @return int|null
+	 */
+	public function getTest(): ?int
+	{
+		return $this->test;
+	}
+
+	/**
+	 * @return int|null
+	 */
+	public function getAnotherTest(): ?int
+	{
+		return $this->anotherTest;
+	}
+
+	/**
+	 * @param int|null $test
+	 * @return self
+	 */
+	public function setTest(?int $test): self
+	{
+		$this->test = $test;
+		return $this;
+	}
+
+	/**
+	 * @param int|null $anotherTest
+	 * @return self
+	 */
+	public function setAnotherTest(?int $anotherTest): self
+	{
+		$this->anotherTest = $anotherTest;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setTest($data['test'] ?? null);
+		$instance->setAnotherTest($data['another_test'] ?? null);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test,
+			'another_test' => $this->another_test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_7_4_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_7_4_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
@@ -44,9 +44,9 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'simple_nesting' => array_map(function($item) {
+			'simple_nesting' => array_map(static function($item) {
 				    return $item->toArray();
-			}, $this->simple_nesting)
+			}, $this->simpleNesting)
 		];
 	}
 }
@@ -167,7 +167,7 @@ class SimpleNesting
 	public function toArray(): array
 	{
 		return [
-			'always_present' => $this->always_present,
+			'always_present' => $this->alwaysPresent,
 			'string' => $this->string,
 			'object' => $this->object !== null ? $this->object->toArray() : null,
 			'number' => $this->number
@@ -244,7 +244,7 @@ class Object
 	{
 		return [
 			'test' => $this->test,
-			'another_test' => $this->another_test
+			'another_test' => $this->anotherTest
 		];
 	}
 }

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_7_4_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_7_4_with_to_array_method.txt
@@ -8,9 +8,9 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'simple_nesting' => array_map(function($item) {
+			'simple_nesting' => array_map(static function($item) {
 				    return $item->toArray();
-			}, $this->simple_nesting)
+			}, $this->simpleNesting)
 		];
 	}
 }
@@ -27,7 +27,7 @@ class SimpleNesting
 	public function toArray(): array
 	{
 		return [
-			'always_present' => $this->always_present,
+			'always_present' => $this->alwaysPresent,
 			'string' => $this->string,
 			'object' => $this->object !== null ? $this->object->toArray() : null,
 			'number' => $this->number
@@ -46,7 +46,7 @@ class Object
 	{
 		return [
 			'test' => $this->test,
-			'another_test' => $this->another_test
+			'another_test' => $this->anotherTest
 		];
 	}
 }

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_7_4_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_7_4_with_to_array_method.txt
@@ -1,0 +1,61 @@
+<?php
+
+class RootObject
+{
+	/** @var SimpleNesting[] */
+	public array $simpleNesting;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'simple_nesting' => array_map(function($item) {
+				    return $item->toArray();
+			}, $this->simple_nesting)
+		];
+	}
+}
+
+<?php
+
+class SimpleNesting
+{
+	public float $alwaysPresent;
+	public ?string $string;
+	public ?Object $object;
+	public ?int $number;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'always_present' => $this->always_present,
+			'string' => $this->string,
+			'object' => $this->object !== null ? $this->object->toArray() : null,
+			'number' => $this->number
+		];
+	}
+}
+
+<?php
+
+class Object
+{
+	public ?int $test;
+	public ?int $anotherTest;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test,
+			'another_test' => $this->another_test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_7_4_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_7_4_with_to_array_method.txt
@@ -5,9 +5,6 @@ class RootObject
 	/** @var SimpleNesting[] */
 	public array $simpleNesting;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -27,9 +24,6 @@ class SimpleNesting
 	public ?Object $object;
 	public ?int $number;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -48,9 +42,6 @@ class Object
 	public ?int $test;
 	public ?int $anotherTest;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_0_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_0_with_from_json_and_to_array_methods.txt
@@ -17,9 +17,9 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'simple_nesting' => array_map(function($item) {
+			'simple_nesting' => array_map(static function($item) {
 				    return $item->toArray();
-			}, $this->simple_nesting)
+			}, $this->simpleNesting)
 		];
 	}
 }
@@ -46,7 +46,7 @@ class SimpleNesting
 	public function toArray(): array
 	{
 		return [
-			'always_present' => $this->always_present,
+			'always_present' => $this->alwaysPresent,
 			'string' => $this->string,
 			'object' => $this->object !== null ? $this->object->toArray() : null,
 			'number' => $this->number
@@ -73,7 +73,7 @@ class Object
 	{
 		return [
 			'test' => $this->test,
-			'another_test' => $this->another_test
+			'another_test' => $this->anotherTest
 		];
 	}
 }

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_0_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_0_with_from_json_and_to_array_methods.txt
@@ -14,9 +14,6 @@ class RootObject
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -46,9 +43,6 @@ class SimpleNesting
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -75,9 +69,6 @@ class Object
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_0_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_0_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,88 @@
+<?php
+
+class RootObject
+{
+	/** @var SimpleNesting[] */
+	public array $simpleNesting;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->simpleNesting = array_map(static function($data) {
+			return SimpleNesting::fromJson($data);
+		}, $data->simple_nesting);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'simple_nesting' => array_map(function($item) {
+				    return $item->toArray();
+			}, $this->simple_nesting)
+		];
+	}
+}
+
+<?php
+
+class SimpleNesting
+{
+	public float $alwaysPresent;
+	public ?string $string;
+	public ?Object $object;
+	public ?int $number;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->alwaysPresent = $data->always_present;
+		$instance->string = $data->string ?? null;
+		$instance->object = ($data->object ?? null) !== null ? Object::fromJson($data->object) : null;
+		$instance->number = $data->number ?? null;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'always_present' => $this->always_present,
+			'string' => $this->string,
+			'object' => $this->object !== null ? $this->object->toArray() : null,
+			'number' => $this->number
+		];
+	}
+}
+
+<?php
+
+class Object
+{
+	public ?int $test;
+	public ?int $anotherTest;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->test = $data->test ?? null;
+		$instance->anotherTest = $data->another_test ?? null;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test,
+			'another_test' => $this->another_test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_0_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_0_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
@@ -1,0 +1,250 @@
+<?php
+
+class RootObject
+{
+	/**
+	 * @var SimpleNesting[]
+	 */
+	public array $simpleNesting;
+
+	/**
+	 * @return SimpleNesting[]
+	 */
+	public function getSimpleNesting(): array
+	{
+		return $this->simpleNesting;
+	}
+
+	/**
+	 * @param SimpleNesting[] $simpleNesting
+	 * @return self
+	 */
+	public function setSimpleNesting(array $simpleNesting): self
+	{
+		$this->simpleNesting = $simpleNesting;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setSimpleNesting(array_map(static function($data) {
+			return SimpleNesting::fromJson($data);
+		}, $data['simple_nesting']));
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'simple_nesting' => array_map(function($item) {
+				    return $item->toArray();
+			}, $this->simple_nesting)
+		];
+	}
+}
+
+<?php
+
+class SimpleNesting
+{
+	/**
+	 * @var float
+	 */
+	public float $alwaysPresent;
+
+	/**
+	 * @var string|null
+	 */
+	public ?string $string;
+
+	/**
+	 * @var Object|null
+	 */
+	public ?Object $object;
+
+	/**
+	 * @var int|null
+	 */
+	public ?int $number;
+
+	/**
+	 * @return float
+	 */
+	public function getAlwaysPresent(): float
+	{
+		return $this->alwaysPresent;
+	}
+
+	/**
+	 * @return string|null
+	 */
+	public function getString(): ?string
+	{
+		return $this->string;
+	}
+
+	/**
+	 * @return Object|null
+	 */
+	public function getObject(): ?Object
+	{
+		return $this->object;
+	}
+
+	/**
+	 * @return int|null
+	 */
+	public function getNumber(): ?int
+	{
+		return $this->number;
+	}
+
+	/**
+	 * @param float $alwaysPresent
+	 * @return self
+	 */
+	public function setAlwaysPresent(float $alwaysPresent): self
+	{
+		$this->alwaysPresent = $alwaysPresent;
+		return $this;
+	}
+
+	/**
+	 * @param string|null $string
+	 * @return self
+	 */
+	public function setString(?string $string): self
+	{
+		$this->string = $string;
+		return $this;
+	}
+
+	/**
+	 * @param Object|null $object
+	 * @return self
+	 */
+	public function setObject(?Object $object): self
+	{
+		$this->object = $object;
+		return $this;
+	}
+
+	/**
+	 * @param int|null $number
+	 * @return self
+	 */
+	public function setNumber(?int $number): self
+	{
+		$this->number = $number;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setAlwaysPresent($data['always_present']);
+		$instance->setString($data['string'] ?? null);
+		$instance->setObject(($data['object'] ?? null) !== null ? Object::fromJson($data['object']) : null);
+		$instance->setNumber($data['number'] ?? null);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'always_present' => $this->always_present,
+			'string' => $this->string,
+			'object' => $this->object !== null ? $this->object->toArray() : null,
+			'number' => $this->number
+		];
+	}
+}
+
+<?php
+
+class Object
+{
+	/**
+	 * @var int|null
+	 */
+	public ?int $test;
+
+	/**
+	 * @var int|null
+	 */
+	public ?int $anotherTest;
+
+	/**
+	 * @return int|null
+	 */
+	public function getTest(): ?int
+	{
+		return $this->test;
+	}
+
+	/**
+	 * @return int|null
+	 */
+	public function getAnotherTest(): ?int
+	{
+		return $this->anotherTest;
+	}
+
+	/**
+	 * @param int|null $test
+	 * @return self
+	 */
+	public function setTest(?int $test): self
+	{
+		$this->test = $test;
+		return $this;
+	}
+
+	/**
+	 * @param int|null $anotherTest
+	 * @return self
+	 */
+	public function setAnotherTest(?int $anotherTest): self
+	{
+		$this->anotherTest = $anotherTest;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setTest($data['test'] ?? null);
+		$instance->setAnotherTest($data['another_test'] ?? null);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test,
+			'another_test' => $this->another_test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_0_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_0_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
@@ -44,9 +44,9 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'simple_nesting' => array_map(function($item) {
+			'simple_nesting' => array_map(static function($item) {
 				    return $item->toArray();
-			}, $this->simple_nesting)
+			}, $this->simpleNesting)
 		];
 	}
 }
@@ -167,7 +167,7 @@ class SimpleNesting
 	public function toArray(): array
 	{
 		return [
-			'always_present' => $this->always_present,
+			'always_present' => $this->alwaysPresent,
 			'string' => $this->string,
 			'object' => $this->object !== null ? $this->object->toArray() : null,
 			'number' => $this->number
@@ -244,7 +244,7 @@ class Object
 	{
 		return [
 			'test' => $this->test,
-			'another_test' => $this->another_test
+			'another_test' => $this->anotherTest
 		];
 	}
 }

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_0_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_0_with_to_array_method.txt
@@ -8,9 +8,9 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'simple_nesting' => array_map(function($item) {
+			'simple_nesting' => array_map(static function($item) {
 				    return $item->toArray();
-			}, $this->simple_nesting)
+			}, $this->simpleNesting)
 		];
 	}
 }
@@ -27,7 +27,7 @@ class SimpleNesting
 	public function toArray(): array
 	{
 		return [
-			'always_present' => $this->always_present,
+			'always_present' => $this->alwaysPresent,
 			'string' => $this->string,
 			'object' => $this->object !== null ? $this->object->toArray() : null,
 			'number' => $this->number
@@ -46,7 +46,7 @@ class Object
 	{
 		return [
 			'test' => $this->test,
-			'another_test' => $this->another_test
+			'another_test' => $this->anotherTest
 		];
 	}
 }

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_0_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_0_with_to_array_method.txt
@@ -1,0 +1,61 @@
+<?php
+
+class RootObject
+{
+	/** @var SimpleNesting[] */
+	public array $simpleNesting;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'simple_nesting' => array_map(function($item) {
+				    return $item->toArray();
+			}, $this->simple_nesting)
+		];
+	}
+}
+
+<?php
+
+class SimpleNesting
+{
+	public float $alwaysPresent;
+	public ?string $string;
+	public ?Object $object;
+	public ?int $number;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'always_present' => $this->always_present,
+			'string' => $this->string,
+			'object' => $this->object !== null ? $this->object->toArray() : null,
+			'number' => $this->number
+		];
+	}
+}
+
+<?php
+
+class Object
+{
+	public ?int $test;
+	public ?int $anotherTest;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test,
+			'another_test' => $this->another_test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_0_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_0_with_to_array_method.txt
@@ -5,9 +5,6 @@ class RootObject
 	/** @var SimpleNesting[] */
 	public array $simpleNesting;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -27,9 +24,6 @@ class SimpleNesting
 	public ?Object $object;
 	public ?int $number;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -48,9 +42,6 @@ class Object
 	public ?int $test;
 	public ?int $anotherTest;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_1_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_1_with_from_json_and_to_array_methods.txt
@@ -17,9 +17,9 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'simple_nesting' => array_map(function($item) {
+			'simple_nesting' => array_map(static function($item) {
 				    return $item->toArray();
-			}, $this->simple_nesting)
+			}, $this->simpleNesting)
 		];
 	}
 }
@@ -46,7 +46,7 @@ class SimpleNesting
 	public function toArray(): array
 	{
 		return [
-			'always_present' => $this->always_present,
+			'always_present' => $this->alwaysPresent,
 			'string' => $this->string,
 			'object' => $this->object !== null ? $this->object->toArray() : null,
 			'number' => $this->number
@@ -73,7 +73,7 @@ class Object
 	{
 		return [
 			'test' => $this->test,
-			'another_test' => $this->another_test
+			'another_test' => $this->anotherTest
 		];
 	}
 }

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_1_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_1_with_from_json_and_to_array_methods.txt
@@ -14,9 +14,6 @@ class RootObject
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -46,9 +43,6 @@ class SimpleNesting
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -75,9 +69,6 @@ class Object
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_1_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_1_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,88 @@
+<?php
+
+class RootObject
+{
+	/** @var SimpleNesting[] */
+	public array $simpleNesting;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->simpleNesting = array_map(static function($data) {
+			return SimpleNesting::fromJson($data);
+		}, $data->simple_nesting);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'simple_nesting' => array_map(function($item) {
+				    return $item->toArray();
+			}, $this->simple_nesting)
+		];
+	}
+}
+
+<?php
+
+class SimpleNesting
+{
+	public float $alwaysPresent;
+	public ?string $string;
+	public ?Object $object;
+	public ?int $number;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->alwaysPresent = $data->always_present;
+		$instance->string = $data->string ?? null;
+		$instance->object = ($data->object ?? null) !== null ? Object::fromJson($data->object) : null;
+		$instance->number = $data->number ?? null;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'always_present' => $this->always_present,
+			'string' => $this->string,
+			'object' => $this->object !== null ? $this->object->toArray() : null,
+			'number' => $this->number
+		];
+	}
+}
+
+<?php
+
+class Object
+{
+	public ?int $test;
+	public ?int $anotherTest;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->test = $data->test ?? null;
+		$instance->anotherTest = $data->another_test ?? null;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test,
+			'another_test' => $this->another_test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_1_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_1_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
@@ -1,0 +1,250 @@
+<?php
+
+class RootObject
+{
+	/**
+	 * @var SimpleNesting[]
+	 */
+	public array $simpleNesting;
+
+	/**
+	 * @return SimpleNesting[]
+	 */
+	public function getSimpleNesting(): array
+	{
+		return $this->simpleNesting;
+	}
+
+	/**
+	 * @param SimpleNesting[] $simpleNesting
+	 * @return self
+	 */
+	public function setSimpleNesting(array $simpleNesting): self
+	{
+		$this->simpleNesting = $simpleNesting;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setSimpleNesting(array_map(static function($data) {
+			return SimpleNesting::fromJson($data);
+		}, $data['simple_nesting']));
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'simple_nesting' => array_map(function($item) {
+				    return $item->toArray();
+			}, $this->simple_nesting)
+		];
+	}
+}
+
+<?php
+
+class SimpleNesting
+{
+	/**
+	 * @var float
+	 */
+	public float $alwaysPresent;
+
+	/**
+	 * @var string|null
+	 */
+	public ?string $string;
+
+	/**
+	 * @var Object|null
+	 */
+	public ?Object $object;
+
+	/**
+	 * @var int|null
+	 */
+	public ?int $number;
+
+	/**
+	 * @return float
+	 */
+	public function getAlwaysPresent(): float
+	{
+		return $this->alwaysPresent;
+	}
+
+	/**
+	 * @return string|null
+	 */
+	public function getString(): ?string
+	{
+		return $this->string;
+	}
+
+	/**
+	 * @return Object|null
+	 */
+	public function getObject(): ?Object
+	{
+		return $this->object;
+	}
+
+	/**
+	 * @return int|null
+	 */
+	public function getNumber(): ?int
+	{
+		return $this->number;
+	}
+
+	/**
+	 * @param float $alwaysPresent
+	 * @return self
+	 */
+	public function setAlwaysPresent(float $alwaysPresent): self
+	{
+		$this->alwaysPresent = $alwaysPresent;
+		return $this;
+	}
+
+	/**
+	 * @param string|null $string
+	 * @return self
+	 */
+	public function setString(?string $string): self
+	{
+		$this->string = $string;
+		return $this;
+	}
+
+	/**
+	 * @param Object|null $object
+	 * @return self
+	 */
+	public function setObject(?Object $object): self
+	{
+		$this->object = $object;
+		return $this;
+	}
+
+	/**
+	 * @param int|null $number
+	 * @return self
+	 */
+	public function setNumber(?int $number): self
+	{
+		$this->number = $number;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setAlwaysPresent($data['always_present']);
+		$instance->setString($data['string'] ?? null);
+		$instance->setObject(($data['object'] ?? null) !== null ? Object::fromJson($data['object']) : null);
+		$instance->setNumber($data['number'] ?? null);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'always_present' => $this->always_present,
+			'string' => $this->string,
+			'object' => $this->object !== null ? $this->object->toArray() : null,
+			'number' => $this->number
+		];
+	}
+}
+
+<?php
+
+class Object
+{
+	/**
+	 * @var int|null
+	 */
+	public ?int $test;
+
+	/**
+	 * @var int|null
+	 */
+	public ?int $anotherTest;
+
+	/**
+	 * @return int|null
+	 */
+	public function getTest(): ?int
+	{
+		return $this->test;
+	}
+
+	/**
+	 * @return int|null
+	 */
+	public function getAnotherTest(): ?int
+	{
+		return $this->anotherTest;
+	}
+
+	/**
+	 * @param int|null $test
+	 * @return self
+	 */
+	public function setTest(?int $test): self
+	{
+		$this->test = $test;
+		return $this;
+	}
+
+	/**
+	 * @param int|null $anotherTest
+	 * @return self
+	 */
+	public function setAnotherTest(?int $anotherTest): self
+	{
+		$this->anotherTest = $anotherTest;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setTest($data['test'] ?? null);
+		$instance->setAnotherTest($data['another_test'] ?? null);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test,
+			'another_test' => $this->another_test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_1_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_1_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
@@ -44,9 +44,9 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'simple_nesting' => array_map(function($item) {
+			'simple_nesting' => array_map(static function($item) {
 				    return $item->toArray();
-			}, $this->simple_nesting)
+			}, $this->simpleNesting)
 		];
 	}
 }
@@ -167,7 +167,7 @@ class SimpleNesting
 	public function toArray(): array
 	{
 		return [
-			'always_present' => $this->always_present,
+			'always_present' => $this->alwaysPresent,
 			'string' => $this->string,
 			'object' => $this->object !== null ? $this->object->toArray() : null,
 			'number' => $this->number
@@ -244,7 +244,7 @@ class Object
 	{
 		return [
 			'test' => $this->test,
-			'another_test' => $this->another_test
+			'another_test' => $this->anotherTest
 		];
 	}
 }

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_1_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_1_with_to_array_method.txt
@@ -8,9 +8,9 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'simple_nesting' => array_map(function($item) {
+			'simple_nesting' => array_map(static function($item) {
 				    return $item->toArray();
-			}, $this->simple_nesting)
+			}, $this->simpleNesting)
 		];
 	}
 }
@@ -27,7 +27,7 @@ class SimpleNesting
 	public function toArray(): array
 	{
 		return [
-			'always_present' => $this->always_present,
+			'always_present' => $this->alwaysPresent,
 			'string' => $this->string,
 			'object' => $this->object !== null ? $this->object->toArray() : null,
 			'number' => $this->number
@@ -46,7 +46,7 @@ class Object
 	{
 		return [
 			'test' => $this->test,
-			'another_test' => $this->another_test
+			'another_test' => $this->anotherTest
 		];
 	}
 }

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_1_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_1_with_to_array_method.txt
@@ -1,0 +1,61 @@
+<?php
+
+class RootObject
+{
+	/** @var SimpleNesting[] */
+	public array $simpleNesting;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'simple_nesting' => array_map(function($item) {
+				    return $item->toArray();
+			}, $this->simple_nesting)
+		];
+	}
+}
+
+<?php
+
+class SimpleNesting
+{
+	public float $alwaysPresent;
+	public ?string $string;
+	public ?Object $object;
+	public ?int $number;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'always_present' => $this->always_present,
+			'string' => $this->string,
+			'object' => $this->object !== null ? $this->object->toArray() : null,
+			'number' => $this->number
+		];
+	}
+}
+
+<?php
+
+class Object
+{
+	public ?int $test;
+	public ?int $anotherTest;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test,
+			'another_test' => $this->another_test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_1_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_1_with_to_array_method.txt
@@ -5,9 +5,6 @@ class RootObject
 	/** @var SimpleNesting[] */
 	public array $simpleNesting;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -27,9 +24,6 @@ class SimpleNesting
 	public ?Object $object;
 	public ?int $number;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -48,9 +42,6 @@ class Object
 	public ?int $test;
 	public ?int $anotherTest;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_2_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_2_with_from_json_and_to_array_methods.txt
@@ -17,9 +17,9 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'simple_nesting' => array_map(function($item) {
+			'simple_nesting' => array_map(static function($item) {
 				    return $item->toArray();
-			}, $this->simple_nesting)
+			}, $this->simpleNesting)
 		];
 	}
 }
@@ -46,7 +46,7 @@ class SimpleNesting
 	public function toArray(): array
 	{
 		return [
-			'always_present' => $this->always_present,
+			'always_present' => $this->alwaysPresent,
 			'string' => $this->string,
 			'object' => $this->object !== null ? $this->object->toArray() : null,
 			'number' => $this->number
@@ -73,7 +73,7 @@ class Object
 	{
 		return [
 			'test' => $this->test,
-			'another_test' => $this->another_test
+			'another_test' => $this->anotherTest
 		];
 	}
 }

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_2_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_2_with_from_json_and_to_array_methods.txt
@@ -14,9 +14,6 @@ class RootObject
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -46,9 +43,6 @@ class SimpleNesting
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -75,9 +69,6 @@ class Object
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_2_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_2_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,88 @@
+<?php
+
+class RootObject
+{
+	/** @var SimpleNesting[] */
+	public array $simpleNesting;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->simpleNesting = array_map(static function($data) {
+			return SimpleNesting::fromJson($data);
+		}, $data->simple_nesting);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'simple_nesting' => array_map(function($item) {
+				    return $item->toArray();
+			}, $this->simple_nesting)
+		];
+	}
+}
+
+<?php
+
+class SimpleNesting
+{
+	public float $alwaysPresent;
+	public ?string $string;
+	public ?Object $object;
+	public ?int $number;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->alwaysPresent = $data->always_present;
+		$instance->string = $data->string ?? null;
+		$instance->object = ($data->object ?? null) !== null ? Object::fromJson($data->object) : null;
+		$instance->number = $data->number ?? null;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'always_present' => $this->always_present,
+			'string' => $this->string,
+			'object' => $this->object !== null ? $this->object->toArray() : null,
+			'number' => $this->number
+		];
+	}
+}
+
+<?php
+
+class Object
+{
+	public ?int $test;
+	public ?int $anotherTest;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->test = $data->test ?? null;
+		$instance->anotherTest = $data->another_test ?? null;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test,
+			'another_test' => $this->another_test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_2_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_2_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
@@ -1,0 +1,250 @@
+<?php
+
+class RootObject
+{
+	/**
+	 * @var SimpleNesting[]
+	 */
+	public array $simpleNesting;
+
+	/**
+	 * @return SimpleNesting[]
+	 */
+	public function getSimpleNesting(): array
+	{
+		return $this->simpleNesting;
+	}
+
+	/**
+	 * @param SimpleNesting[] $simpleNesting
+	 * @return self
+	 */
+	public function setSimpleNesting(array $simpleNesting): self
+	{
+		$this->simpleNesting = $simpleNesting;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setSimpleNesting(array_map(static function($data) {
+			return SimpleNesting::fromJson($data);
+		}, $data['simple_nesting']));
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'simple_nesting' => array_map(function($item) {
+				    return $item->toArray();
+			}, $this->simple_nesting)
+		];
+	}
+}
+
+<?php
+
+class SimpleNesting
+{
+	/**
+	 * @var float
+	 */
+	public float $alwaysPresent;
+
+	/**
+	 * @var string|null
+	 */
+	public ?string $string;
+
+	/**
+	 * @var Object|null
+	 */
+	public ?Object $object;
+
+	/**
+	 * @var int|null
+	 */
+	public ?int $number;
+
+	/**
+	 * @return float
+	 */
+	public function getAlwaysPresent(): float
+	{
+		return $this->alwaysPresent;
+	}
+
+	/**
+	 * @return string|null
+	 */
+	public function getString(): ?string
+	{
+		return $this->string;
+	}
+
+	/**
+	 * @return Object|null
+	 */
+	public function getObject(): ?Object
+	{
+		return $this->object;
+	}
+
+	/**
+	 * @return int|null
+	 */
+	public function getNumber(): ?int
+	{
+		return $this->number;
+	}
+
+	/**
+	 * @param float $alwaysPresent
+	 * @return self
+	 */
+	public function setAlwaysPresent(float $alwaysPresent): self
+	{
+		$this->alwaysPresent = $alwaysPresent;
+		return $this;
+	}
+
+	/**
+	 * @param string|null $string
+	 * @return self
+	 */
+	public function setString(?string $string): self
+	{
+		$this->string = $string;
+		return $this;
+	}
+
+	/**
+	 * @param Object|null $object
+	 * @return self
+	 */
+	public function setObject(?Object $object): self
+	{
+		$this->object = $object;
+		return $this;
+	}
+
+	/**
+	 * @param int|null $number
+	 * @return self
+	 */
+	public function setNumber(?int $number): self
+	{
+		$this->number = $number;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setAlwaysPresent($data['always_present']);
+		$instance->setString($data['string'] ?? null);
+		$instance->setObject(($data['object'] ?? null) !== null ? Object::fromJson($data['object']) : null);
+		$instance->setNumber($data['number'] ?? null);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'always_present' => $this->always_present,
+			'string' => $this->string,
+			'object' => $this->object !== null ? $this->object->toArray() : null,
+			'number' => $this->number
+		];
+	}
+}
+
+<?php
+
+class Object
+{
+	/**
+	 * @var int|null
+	 */
+	public ?int $test;
+
+	/**
+	 * @var int|null
+	 */
+	public ?int $anotherTest;
+
+	/**
+	 * @return int|null
+	 */
+	public function getTest(): ?int
+	{
+		return $this->test;
+	}
+
+	/**
+	 * @return int|null
+	 */
+	public function getAnotherTest(): ?int
+	{
+		return $this->anotherTest;
+	}
+
+	/**
+	 * @param int|null $test
+	 * @return self
+	 */
+	public function setTest(?int $test): self
+	{
+		$this->test = $test;
+		return $this;
+	}
+
+	/**
+	 * @param int|null $anotherTest
+	 * @return self
+	 */
+	public function setAnotherTest(?int $anotherTest): self
+	{
+		$this->anotherTest = $anotherTest;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setTest($data['test'] ?? null);
+		$instance->setAnotherTest($data['another_test'] ?? null);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test,
+			'another_test' => $this->another_test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_2_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_2_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
@@ -44,9 +44,9 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'simple_nesting' => array_map(function($item) {
+			'simple_nesting' => array_map(static function($item) {
 				    return $item->toArray();
-			}, $this->simple_nesting)
+			}, $this->simpleNesting)
 		];
 	}
 }
@@ -167,7 +167,7 @@ class SimpleNesting
 	public function toArray(): array
 	{
 		return [
-			'always_present' => $this->always_present,
+			'always_present' => $this->alwaysPresent,
 			'string' => $this->string,
 			'object' => $this->object !== null ? $this->object->toArray() : null,
 			'number' => $this->number
@@ -244,7 +244,7 @@ class Object
 	{
 		return [
 			'test' => $this->test,
-			'another_test' => $this->another_test
+			'another_test' => $this->anotherTest
 		];
 	}
 }

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_2_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_2_with_to_array_method.txt
@@ -8,9 +8,9 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'simple_nesting' => array_map(function($item) {
+			'simple_nesting' => array_map(static function($item) {
 				    return $item->toArray();
-			}, $this->simple_nesting)
+			}, $this->simpleNesting)
 		];
 	}
 }
@@ -27,7 +27,7 @@ class SimpleNesting
 	public function toArray(): array
 	{
 		return [
-			'always_present' => $this->always_present,
+			'always_present' => $this->alwaysPresent,
 			'string' => $this->string,
 			'object' => $this->object !== null ? $this->object->toArray() : null,
 			'number' => $this->number
@@ -46,7 +46,7 @@ class Object
 	{
 		return [
 			'test' => $this->test,
-			'another_test' => $this->another_test
+			'another_test' => $this->anotherTest
 		];
 	}
 }

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_2_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_2_with_to_array_method.txt
@@ -1,0 +1,61 @@
+<?php
+
+class RootObject
+{
+	/** @var SimpleNesting[] */
+	public array $simpleNesting;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'simple_nesting' => array_map(function($item) {
+				    return $item->toArray();
+			}, $this->simple_nesting)
+		];
+	}
+}
+
+<?php
+
+class SimpleNesting
+{
+	public float $alwaysPresent;
+	public ?string $string;
+	public ?Object $object;
+	public ?int $number;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'always_present' => $this->always_present,
+			'string' => $this->string,
+			'object' => $this->object !== null ? $this->object->toArray() : null,
+			'number' => $this->number
+		];
+	}
+}
+
+<?php
+
+class Object
+{
+	public ?int $test;
+	public ?int $anotherTest;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test,
+			'another_test' => $this->another_test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_2_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_2_with_to_array_method.txt
@@ -5,9 +5,6 @@ class RootObject
 	/** @var SimpleNesting[] */
 	public array $simpleNesting;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -27,9 +24,6 @@ class SimpleNesting
 	public ?Object $object;
 	public ?int $number;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -48,9 +42,6 @@ class Object
 	public ?int $test;
 	public ?int $anotherTest;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_3_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_3_with_from_json_and_to_array_methods.txt
@@ -17,9 +17,9 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'simple_nesting' => array_map(function($item) {
+			'simple_nesting' => array_map(static function($item) {
 				    return $item->toArray();
-			}, $this->simple_nesting)
+			}, $this->simpleNesting)
 		];
 	}
 }
@@ -46,7 +46,7 @@ class SimpleNesting
 	public function toArray(): array
 	{
 		return [
-			'always_present' => $this->always_present,
+			'always_present' => $this->alwaysPresent,
 			'string' => $this->string,
 			'object' => $this->object !== null ? $this->object->toArray() : null,
 			'number' => $this->number
@@ -73,7 +73,7 @@ class Object
 	{
 		return [
 			'test' => $this->test,
-			'another_test' => $this->another_test
+			'another_test' => $this->anotherTest
 		];
 	}
 }

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_3_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_3_with_from_json_and_to_array_methods.txt
@@ -14,9 +14,6 @@ class RootObject
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -46,9 +43,6 @@ class SimpleNesting
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -75,9 +69,6 @@ class Object
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_3_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_3_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,88 @@
+<?php
+
+class RootObject
+{
+	/** @var SimpleNesting[] */
+	public array $simpleNesting;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->simpleNesting = array_map(static function($data) {
+			return SimpleNesting::fromJson($data);
+		}, $data->simple_nesting);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'simple_nesting' => array_map(function($item) {
+				    return $item->toArray();
+			}, $this->simple_nesting)
+		];
+	}
+}
+
+<?php
+
+class SimpleNesting
+{
+	public float $alwaysPresent;
+	public ?string $string;
+	public ?Object $object;
+	public ?int $number;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->alwaysPresent = $data->always_present;
+		$instance->string = $data->string ?? null;
+		$instance->object = ($data->object ?? null) !== null ? Object::fromJson($data->object) : null;
+		$instance->number = $data->number ?? null;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'always_present' => $this->always_present,
+			'string' => $this->string,
+			'object' => $this->object !== null ? $this->object->toArray() : null,
+			'number' => $this->number
+		];
+	}
+}
+
+<?php
+
+class Object
+{
+	public ?int $test;
+	public ?int $anotherTest;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->test = $data->test ?? null;
+		$instance->anotherTest = $data->another_test ?? null;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test,
+			'another_test' => $this->another_test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_3_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_3_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
@@ -1,0 +1,250 @@
+<?php
+
+class RootObject
+{
+	/**
+	 * @var SimpleNesting[]
+	 */
+	public array $simpleNesting;
+
+	/**
+	 * @return SimpleNesting[]
+	 */
+	public function getSimpleNesting(): array
+	{
+		return $this->simpleNesting;
+	}
+
+	/**
+	 * @param SimpleNesting[] $simpleNesting
+	 * @return self
+	 */
+	public function setSimpleNesting(array $simpleNesting): self
+	{
+		$this->simpleNesting = $simpleNesting;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setSimpleNesting(array_map(static function($data) {
+			return SimpleNesting::fromJson($data);
+		}, $data['simple_nesting']));
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'simple_nesting' => array_map(function($item) {
+				    return $item->toArray();
+			}, $this->simple_nesting)
+		];
+	}
+}
+
+<?php
+
+class SimpleNesting
+{
+	/**
+	 * @var float
+	 */
+	public float $alwaysPresent;
+
+	/**
+	 * @var string|null
+	 */
+	public ?string $string;
+
+	/**
+	 * @var Object|null
+	 */
+	public ?Object $object;
+
+	/**
+	 * @var int|null
+	 */
+	public ?int $number;
+
+	/**
+	 * @return float
+	 */
+	public function getAlwaysPresent(): float
+	{
+		return $this->alwaysPresent;
+	}
+
+	/**
+	 * @return string|null
+	 */
+	public function getString(): ?string
+	{
+		return $this->string;
+	}
+
+	/**
+	 * @return Object|null
+	 */
+	public function getObject(): ?Object
+	{
+		return $this->object;
+	}
+
+	/**
+	 * @return int|null
+	 */
+	public function getNumber(): ?int
+	{
+		return $this->number;
+	}
+
+	/**
+	 * @param float $alwaysPresent
+	 * @return self
+	 */
+	public function setAlwaysPresent(float $alwaysPresent): self
+	{
+		$this->alwaysPresent = $alwaysPresent;
+		return $this;
+	}
+
+	/**
+	 * @param string|null $string
+	 * @return self
+	 */
+	public function setString(?string $string): self
+	{
+		$this->string = $string;
+		return $this;
+	}
+
+	/**
+	 * @param Object|null $object
+	 * @return self
+	 */
+	public function setObject(?Object $object): self
+	{
+		$this->object = $object;
+		return $this;
+	}
+
+	/**
+	 * @param int|null $number
+	 * @return self
+	 */
+	public function setNumber(?int $number): self
+	{
+		$this->number = $number;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setAlwaysPresent($data['always_present']);
+		$instance->setString($data['string'] ?? null);
+		$instance->setObject(($data['object'] ?? null) !== null ? Object::fromJson($data['object']) : null);
+		$instance->setNumber($data['number'] ?? null);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'always_present' => $this->always_present,
+			'string' => $this->string,
+			'object' => $this->object !== null ? $this->object->toArray() : null,
+			'number' => $this->number
+		];
+	}
+}
+
+<?php
+
+class Object
+{
+	/**
+	 * @var int|null
+	 */
+	public ?int $test;
+
+	/**
+	 * @var int|null
+	 */
+	public ?int $anotherTest;
+
+	/**
+	 * @return int|null
+	 */
+	public function getTest(): ?int
+	{
+		return $this->test;
+	}
+
+	/**
+	 * @return int|null
+	 */
+	public function getAnotherTest(): ?int
+	{
+		return $this->anotherTest;
+	}
+
+	/**
+	 * @param int|null $test
+	 * @return self
+	 */
+	public function setTest(?int $test): self
+	{
+		$this->test = $test;
+		return $this;
+	}
+
+	/**
+	 * @param int|null $anotherTest
+	 * @return self
+	 */
+	public function setAnotherTest(?int $anotherTest): self
+	{
+		$this->anotherTest = $anotherTest;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setTest($data['test'] ?? null);
+		$instance->setAnotherTest($data['another_test'] ?? null);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test,
+			'another_test' => $this->another_test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_3_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_3_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
@@ -44,9 +44,9 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'simple_nesting' => array_map(function($item) {
+			'simple_nesting' => array_map(static function($item) {
 				    return $item->toArray();
-			}, $this->simple_nesting)
+			}, $this->simpleNesting)
 		];
 	}
 }
@@ -167,7 +167,7 @@ class SimpleNesting
 	public function toArray(): array
 	{
 		return [
-			'always_present' => $this->always_present,
+			'always_present' => $this->alwaysPresent,
 			'string' => $this->string,
 			'object' => $this->object !== null ? $this->object->toArray() : null,
 			'number' => $this->number
@@ -244,7 +244,7 @@ class Object
 	{
 		return [
 			'test' => $this->test,
-			'another_test' => $this->another_test
+			'another_test' => $this->anotherTest
 		];
 	}
 }

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_3_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_3_with_to_array_method.txt
@@ -8,9 +8,9 @@ class RootObject
 	public function toArray(): array
 	{
 		return [
-			'simple_nesting' => array_map(function($item) {
+			'simple_nesting' => array_map(static function($item) {
 				    return $item->toArray();
-			}, $this->simple_nesting)
+			}, $this->simpleNesting)
 		];
 	}
 }
@@ -27,7 +27,7 @@ class SimpleNesting
 	public function toArray(): array
 	{
 		return [
-			'always_present' => $this->always_present,
+			'always_present' => $this->alwaysPresent,
 			'string' => $this->string,
 			'object' => $this->object !== null ? $this->object->toArray() : null,
 			'number' => $this->number
@@ -46,7 +46,7 @@ class Object
 	{
 		return [
 			'test' => $this->test,
-			'another_test' => $this->another_test
+			'another_test' => $this->anotherTest
 		];
 	}
 }

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_3_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_3_with_to_array_method.txt
@@ -1,0 +1,61 @@
+<?php
+
+class RootObject
+{
+	/** @var SimpleNesting[] */
+	public array $simpleNesting;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'simple_nesting' => array_map(function($item) {
+				    return $item->toArray();
+			}, $this->simple_nesting)
+		];
+	}
+}
+
+<?php
+
+class SimpleNesting
+{
+	public float $alwaysPresent;
+	public ?string $string;
+	public ?Object $object;
+	public ?int $number;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'always_present' => $this->always_present,
+			'string' => $this->string,
+			'object' => $this->object !== null ? $this->object->toArray() : null,
+			'number' => $this->number
+		];
+	}
+}
+
+<?php
+
+class Object
+{
+	public ?int $test;
+	public ?int $anotherTest;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test,
+			'another_test' => $this->another_test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_3_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_3_with_to_array_method.txt
@@ -5,9 +5,6 @@ class RootObject
 	/** @var SimpleNesting[] */
 	public array $simpleNesting;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -27,9 +24,6 @@ class SimpleNesting
 	public ?Object $object;
 	public ?int $number;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [
@@ -48,9 +42,6 @@ class Object
 	public ?int $test;
 	public ?int $anotherTest;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/simple_json_data_php_7_3_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_7_3_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,23 @@
+<?php
+
+class RootObject
+{
+	public $test;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->test = $data->test;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/simple_json_data_php_7_3_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_7_3_with_from_json_and_to_array_methods.txt
@@ -11,9 +11,6 @@ class RootObject
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/simple_json_data_php_7_3_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_7_3_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
@@ -1,0 +1,48 @@
+<?php
+
+class RootObject
+{
+	/**
+	 * @var int
+	 */
+	public $test;
+
+	/**
+	 * @return int
+	 */
+	public function getTest(): int
+	{
+		return $this->test;
+	}
+
+	/**
+	 * @param int $test
+	 * @return self
+	 */
+	public function setTest(int $test): self
+	{
+		$this->test = $test;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setTest($data['test']);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/simple_json_data_php_7_3_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_7_3_with_to_array_method.txt
@@ -1,0 +1,16 @@
+<?php
+
+class RootObject
+{
+	public $test;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/simple_json_data_php_7_3_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_7_3_with_to_array_method.txt
@@ -4,9 +4,6 @@ class RootObject
 {
 	public $test;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/simple_json_data_php_7_4_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_7_4_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,23 @@
+<?php
+
+class RootObject
+{
+	public int $test;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->test = $data->test;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/simple_json_data_php_7_4_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_7_4_with_from_json_and_to_array_methods.txt
@@ -11,9 +11,6 @@ class RootObject
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/simple_json_data_php_7_4_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_7_4_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
@@ -1,0 +1,48 @@
+<?php
+
+class RootObject
+{
+	/**
+	 * @var int
+	 */
+	public int $test;
+
+	/**
+	 * @return int
+	 */
+	public function getTest(): int
+	{
+		return $this->test;
+	}
+
+	/**
+	 * @param int $test
+	 * @return self
+	 */
+	public function setTest(int $test): self
+	{
+		$this->test = $test;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setTest($data['test']);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/simple_json_data_php_7_4_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_7_4_with_to_array_method.txt
@@ -4,9 +4,6 @@ class RootObject
 {
 	public int $test;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/simple_json_data_php_7_4_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_7_4_with_to_array_method.txt
@@ -1,0 +1,16 @@
+<?php
+
+class RootObject
+{
+	public int $test;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/simple_json_data_php_8_0_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_8_0_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,23 @@
+<?php
+
+class RootObject
+{
+	public int $test;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->test = $data->test;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/simple_json_data_php_8_0_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_8_0_with_from_json_and_to_array_methods.txt
@@ -11,9 +11,6 @@ class RootObject
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/simple_json_data_php_8_0_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_8_0_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
@@ -1,0 +1,48 @@
+<?php
+
+class RootObject
+{
+	/**
+	 * @var int
+	 */
+	public int $test;
+
+	/**
+	 * @return int
+	 */
+	public function getTest(): int
+	{
+		return $this->test;
+	}
+
+	/**
+	 * @param int $test
+	 * @return self
+	 */
+	public function setTest(int $test): self
+	{
+		$this->test = $test;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setTest($data['test']);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/simple_json_data_php_8_0_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_8_0_with_to_array_method.txt
@@ -4,9 +4,6 @@ class RootObject
 {
 	public int $test;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/simple_json_data_php_8_0_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_8_0_with_to_array_method.txt
@@ -1,0 +1,16 @@
+<?php
+
+class RootObject
+{
+	public int $test;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/simple_json_data_php_8_1_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_8_1_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,23 @@
+<?php
+
+class RootObject
+{
+	public int $test;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->test = $data->test;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/simple_json_data_php_8_1_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_8_1_with_from_json_and_to_array_methods.txt
@@ -11,9 +11,6 @@ class RootObject
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/simple_json_data_php_8_1_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_8_1_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
@@ -1,0 +1,48 @@
+<?php
+
+class RootObject
+{
+	/**
+	 * @var int
+	 */
+	public int $test;
+
+	/**
+	 * @return int
+	 */
+	public function getTest(): int
+	{
+		return $this->test;
+	}
+
+	/**
+	 * @param int $test
+	 * @return self
+	 */
+	public function setTest(int $test): self
+	{
+		$this->test = $test;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setTest($data['test']);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/simple_json_data_php_8_1_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_8_1_with_to_array_method.txt
@@ -4,9 +4,6 @@ class RootObject
 {
 	public int $test;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/simple_json_data_php_8_1_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_8_1_with_to_array_method.txt
@@ -1,0 +1,16 @@
+<?php
+
+class RootObject
+{
+	public int $test;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/simple_json_data_php_8_2_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_8_2_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,23 @@
+<?php
+
+class RootObject
+{
+	public int $test;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->test = $data->test;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/simple_json_data_php_8_2_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_8_2_with_from_json_and_to_array_methods.txt
@@ -11,9 +11,6 @@ class RootObject
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/simple_json_data_php_8_2_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_8_2_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
@@ -1,0 +1,48 @@
+<?php
+
+class RootObject
+{
+	/**
+	 * @var int
+	 */
+	public int $test;
+
+	/**
+	 * @return int
+	 */
+	public function getTest(): int
+	{
+		return $this->test;
+	}
+
+	/**
+	 * @param int $test
+	 * @return self
+	 */
+	public function setTest(int $test): self
+	{
+		$this->test = $test;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setTest($data['test']);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/simple_json_data_php_8_2_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_8_2_with_to_array_method.txt
@@ -4,9 +4,6 @@ class RootObject
 {
 	public int $test;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/simple_json_data_php_8_2_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_8_2_with_to_array_method.txt
@@ -1,0 +1,16 @@
+<?php
+
+class RootObject
+{
+	public int $test;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/simple_json_data_php_8_3_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_8_3_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,23 @@
+<?php
+
+class RootObject
+{
+	public int $test;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->test = $data->test;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/simple_json_data_php_8_3_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_8_3_with_from_json_and_to_array_methods.txt
@@ -11,9 +11,6 @@ class RootObject
 		return $instance;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/simple_json_data_php_8_3_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_8_3_with_getters_fluent_setters_all_docblocks_extra_new_lines_for_properties_from_json_method_and_to_array_method.txt
@@ -1,0 +1,48 @@
+<?php
+
+class RootObject
+{
+	/**
+	 * @var int
+	 */
+	public int $test;
+
+	/**
+	 * @return int
+	 */
+	public function getTest(): int
+	{
+		return $this->test;
+	}
+
+	/**
+	 * @param int $test
+	 * @return self
+	 */
+	public function setTest(int $test): self
+	{
+		$this->test = $test;
+		return $this;
+	}
+
+	/**
+	 * @param array $data
+	 * @return self
+	 */
+	public static function fromJson(array $data): self
+	{
+		$instance = new self();
+		$instance->setTest($data['test']);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/simple_json_data_php_8_3_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_8_3_with_to_array_method.txt
@@ -4,9 +4,6 @@ class RootObject
 {
 	public int $test;
 
-	/**
-	 * @return array
-	 */
 	public function toArray(): array
 	{
 		return [

--- a/tests/converter/fixtures/results/simple_json_data_php_8_3_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_8_3_with_to_array_method.txt
@@ -1,0 +1,16 @@
+<?php
+
+class RootObject
+{
+	public int $test;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test
+		];
+	}
+}

--- a/tests/converter/json-to-php-converter.spec.ts
+++ b/tests/converter/json-to-php-converter.spec.ts
@@ -612,6 +612,82 @@ const settingCases = versions.map((version) => {
                 declareStrictTypes: true,
             }
         ],
+        [
+            version + ' with toArray method',
+            {
+                phpVersion: version,
+
+                classCase: StringCase.PascalCase,
+                propertyCase: StringCase.CamelCase,
+
+                propertyVisibility: PhpVisibility.Public,
+                propertyDocblock: PhpDocblock.Necessary,
+                propertyDocblockType: PropertyDocblockType.Inline,
+                propertyAddExtraNewLine: false,
+                readonlyProperties: false,
+
+                addGetters: false,
+                getterCase: StringCase.CamelCase,
+                addSetters: false,
+                setterCase: StringCase.CamelCase,
+                isFluentSetter: false,
+
+                addConstructor: false,
+                constructorPropertyPromotion: false,
+
+                finalClasses: false,
+                readonlyClasses: false,
+                allPropertiesNullable: false,
+
+                addFromJsonMethod: false,
+                jsonIsArray: false,
+                addToArrayMethod: true,
+
+                docblock: PhpDocblock.Necessary,
+
+                rootClassName: 'RootObject',
+                namespace: '',
+                declareStrictTypes: false
+            }
+        ],
+        [
+            version + ' with fromJson and toArray methods',
+            {
+                phpVersion: version,
+
+                classCase: StringCase.PascalCase,
+                propertyCase: StringCase.CamelCase,
+
+                propertyVisibility: PhpVisibility.Public,
+                propertyDocblock: PhpDocblock.Necessary,
+                propertyDocblockType: PropertyDocblockType.Inline,
+                propertyAddExtraNewLine: false,
+                readonlyProperties: false,
+
+                addGetters: false,
+                getterCase: StringCase.CamelCase,
+                addSetters: false,
+                setterCase: StringCase.CamelCase,
+                isFluentSetter: false,
+
+                addConstructor: false,
+                constructorPropertyPromotion: false,
+
+                finalClasses: false,
+                readonlyClasses: false,
+                allPropertiesNullable: false,
+
+                addFromJsonMethod: true,
+                jsonIsArray: false,
+                addToArrayMethod: true,
+
+                docblock: PhpDocblock.Necessary,
+
+                rootClassName: 'RootObject',
+                namespace: '',
+                declareStrictTypes: false
+            }
+        ],
     ];
 
     return value;

--- a/tests/converter/json-to-php-converter.spec.ts
+++ b/tests/converter/json-to-php-converter.spec.ts
@@ -69,6 +69,7 @@ const settingCases = versions.map((version) => {
 
                 addFromJsonMethod: false,
                 jsonIsArray: false,
+                addToArrayMethod: false,
 
                 docblock: PhpDocblock.Necessary,
 
@@ -106,6 +107,7 @@ const settingCases = versions.map((version) => {
 
                 addFromJsonMethod: false,
                 jsonIsArray: false,
+                addToArrayMethod: false,
 
                 docblock: PhpDocblock.Necessary,
 
@@ -143,6 +145,7 @@ const settingCases = versions.map((version) => {
 
                 addFromJsonMethod: false,
                 jsonIsArray: false,
+                addToArrayMethod: false,
 
                 docblock: PhpDocblock.Necessary,
 
@@ -180,6 +183,7 @@ const settingCases = versions.map((version) => {
 
                 addFromJsonMethod: false,
                 jsonIsArray: false,
+                addToArrayMethod: false,
 
                 docblock: PhpDocblock.Necessary,
 
@@ -217,6 +221,7 @@ const settingCases = versions.map((version) => {
 
                 addFromJsonMethod: false,
                 jsonIsArray: false,
+                addToArrayMethod: false,
 
                 docblock: PhpDocblock.Necessary,
 
@@ -254,6 +259,7 @@ const settingCases = versions.map((version) => {
 
                 addFromJsonMethod: false,
                 jsonIsArray: false,
+                addToArrayMethod: false,
 
                 docblock: PhpDocblock.Necessary,
 
@@ -291,6 +297,7 @@ const settingCases = versions.map((version) => {
 
                 addFromJsonMethod: false,
                 jsonIsArray: false,
+                addToArrayMethod: false,
 
                 docblock: PhpDocblock.Necessary,
 
@@ -328,6 +335,7 @@ const settingCases = versions.map((version) => {
 
                 addFromJsonMethod: false,
                 jsonIsArray: false,
+                addToArrayMethod: false,
 
                 docblock: PhpDocblock.Necessary,
 
@@ -365,6 +373,7 @@ const settingCases = versions.map((version) => {
 
                 addFromJsonMethod: true,
                 jsonIsArray: false,
+                addToArrayMethod: false,
 
                 docblock: PhpDocblock.Necessary,
 
@@ -402,6 +411,7 @@ const settingCases = versions.map((version) => {
 
                 addFromJsonMethod: true,
                 jsonIsArray: true,
+                addToArrayMethod: false,
 
                 docblock: PhpDocblock.Necessary,
 
@@ -439,6 +449,7 @@ const settingCases = versions.map((version) => {
 
                 addFromJsonMethod: true,
                 jsonIsArray: false,
+                addToArrayMethod: false,
 
                 docblock: PhpDocblock.Necessary,
 
@@ -476,6 +487,7 @@ const settingCases = versions.map((version) => {
 
                 addFromJsonMethod: true,
                 jsonIsArray: true,
+                addToArrayMethod: false,
 
                 docblock: PhpDocblock.Necessary,
 
@@ -513,6 +525,7 @@ const settingCases = versions.map((version) => {
 
                 addFromJsonMethod: true,
                 jsonIsArray: true,
+                addToArrayMethod: false,
 
                 docblock: PhpDocblock.All,
 
@@ -551,6 +564,7 @@ const settingCases = versions.map((version) => {
 
                 addFromJsonMethod: false,
                 jsonIsArray: false,
+                addToArrayMethod: false,
 
                 docblock: PhpDocblock.Necessary,
 
@@ -589,6 +603,7 @@ const settingCases = versions.map((version) => {
 
                 addFromJsonMethod: false,
                 jsonIsArray: false,
+                addToArrayMethod: false,
 
                 docblock: PhpDocblock.Necessary,
 

--- a/tests/converter/json-to-php-converter.spec.ts
+++ b/tests/converter/json-to-php-converter.spec.ts
@@ -497,7 +497,7 @@ const settingCases = versions.map((version) => {
             }
         ],
         [
-            version + ' with getters, fluent setters, all docblocks, extra new lines for properties and from json method',
+            version + ' with getters, fluent setters, all docblocks, extra new lines for properties, from json method and to array method',
             {
                 phpVersion: version,
 
@@ -525,7 +525,7 @@ const settingCases = versions.map((version) => {
 
                 addFromJsonMethod: true,
                 jsonIsArray: true,
-                addToArrayMethod: false,
+                addToArrayMethod: true,
 
                 docblock: PhpDocblock.All,
 


### PR DESCRIPTION
Preview URL (Deployed on Cloudflare Pages): https://feat-add-toarray-method.json2php-generator.pages.dev

---

- Add PhpClassToArrayMethodPresenter for generating `toArray` method
- Remove unnecessary hasReadonlyProperties check
- Clean up setter generation logic

The toArray method allows converting PHP objects back to arrays, which is a commonly requested feature for data transfer.

Refs #48